### PR TITLE
Date validation refactoring

### DIFF
--- a/app/uk/gov/hmrc/economiccrimelevyregistration/forms/AmlRegulatedActivityStartDateFormProvider.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/forms/AmlRegulatedActivityStartDateFormProvider.scala
@@ -27,13 +27,21 @@ class AmlRegulatedActivityStartDateFormProvider extends Mappings {
     (
       "value",
       localDate(
-        "amlStartDate.error.invalid",
-        "amlStartDate.error.allRequired",
-        "amlStartDate.error.twoRequired",
-        "amlStartDate.error.required"
+        "error.date.invalid",
+        "error.date.required"
       ).verifying(
-        minDate(EclTaxYear.currentFinancialYearStartDate, "amlStartDate.error.notWithinFinancialYear"),
-        maxDate(EclTaxYear.currentFinancialYearEndDate, "amlStartDate.error.notWithinFinancialYear")
+        minDate(
+          EclTaxYear.currentFinancialYearStartDate,
+          "amlStartDate.error.notWithinFinancialYear",
+          EclTaxYear.currentFinancialYearStartDate.getYear.toString,
+          EclTaxYear.currentFinancialYearEndDate.getYear.toString
+        ),
+        maxDate(
+          EclTaxYear.currentFinancialYearEndDate,
+          "amlStartDate.error.notWithinFinancialYear",
+          EclTaxYear.currentFinancialYearStartDate.getYear.toString,
+          EclTaxYear.currentFinancialYearEndDate.getYear.toString
+        )
       )
     )
   )

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/forms/mappings/LocalDateFormatter.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/forms/mappings/LocalDateFormatter.scala
@@ -16,10 +16,10 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.forms.mappings
 
-import java.time.LocalDate
 import play.api.data.FormError
 import play.api.data.format.Formatter
 
+import java.time.LocalDate
 import java.time.temporal.ChronoField
 import scala.util.{Failure, Success, Try}
 
@@ -85,26 +85,20 @@ private[mappings] class LocalDateFormatter(
 
     val validatedDayMonthYear = validateDayMonthYear(key, day, month, year)
 
-    (day, month, year) match {
+    ((day, month, year) match {
       case (Some(day), Some(month), Some(year)) =>
         validatedDayMonthYear match {
-          case Nil        => toDate(key, day.toInt, month.toInt, year.toInt)
-          case formErrors => Left(formErrors)
+          case Nil => toDate(key, day.toInt, month.toInt, year.toInt)
+          case _   => Left(Nil)
         }
-      case (Some(_), None, Some(_))             =>
-        Left(validatedDayMonthYear ++ Seq(FormError(monthKey, "error.month.required")))
-      case (None, Some(_), Some(_))             =>
-        Left(validatedDayMonthYear ++ Seq(FormError(dayKey, "error.day.required")))
-      case (Some(_), Some(_), None)             =>
-        Left(validatedDayMonthYear ++ Seq(FormError(yearKey, "error.year.required")))
-      case (None, None, Some(_))                =>
-        Left(validatedDayMonthYear ++ Seq("day", "month").map(f => FormError(s"$key.$f", s"error.$f.required")))
-      case (None, Some(_), None)                =>
-        Left(validatedDayMonthYear ++ Seq("day", "year").map(f => FormError(s"$key.$f", s"error.$f.required")))
-      case (Some(_), None, None)                =>
-        Left(validatedDayMonthYear ++ Seq("month", "year").map(f => FormError(s"$key.$f", s"error.$f.required")))
-      case _                                    => Left(validatedDayMonthYear ++ Seq(FormError(key, requiredKey, args)))
-    }
+      case (Some(_), None, Some(_))             => Left(Seq(FormError(monthKey, "error.month.required")))
+      case (None, Some(_), Some(_))             => Left(Seq(FormError(dayKey, "error.day.required")))
+      case (Some(_), Some(_), None)             => Left(Seq(FormError(yearKey, "error.year.required")))
+      case (None, None, Some(_))                => Left(Seq("day", "month").map(f => FormError(s"$key.$f", s"error.$f.required")))
+      case (None, Some(_), None)                => Left(Seq("day", "year").map(f => FormError(s"$key.$f", s"error.$f.required")))
+      case (Some(_), None, None)                => Left(Seq("month", "year").map(f => FormError(s"$key.$f", s"error.$f.required")))
+      case _                                    => Left(Seq(FormError(key, requiredKey, args)))
+    }).left.map(_ ++ validatedDayMonthYear)
   }
 
   override def unbind(key: String, value: LocalDate): Map[String, String] =

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/forms/mappings/LocalDateFormatter.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/forms/mappings/LocalDateFormatter.scala
@@ -17,22 +17,18 @@
 package uk.gov.hmrc.economiccrimelevyregistration.forms.mappings
 
 import java.time.LocalDate
-
 import play.api.data.FormError
 import play.api.data.format.Formatter
 
+import java.time.temporal.ChronoField
 import scala.util.{Failure, Success, Try}
 
 private[mappings] class LocalDateFormatter(
   invalidKey: String,
-  allRequiredKey: String,
-  twoRequiredKey: String,
   requiredKey: String,
   args: Seq[String] = Seq.empty
 ) extends Formatter[LocalDate]
     with Formatters {
-
-  private val fieldKeys: List[String] = List("day", "month", "year")
 
   private def toDate(key: String, day: Int, month: Int, year: Int): Either[Seq[FormError], LocalDate] =
     Try(LocalDate.of(year, month, day)) match {
@@ -42,45 +38,72 @@ private[mappings] class LocalDateFormatter(
         Left(Seq(FormError(key, invalidKey, args)))
     }
 
-  private def formatDate(key: String, data: Map[String, String]): Either[Seq[FormError], LocalDate] = {
+  private def validateDayMonthYear(
+    key: String,
+    day: Option[String],
+    month: Option[String],
+    year: Option[String]
+  ): Seq[FormError] = {
+    def validateDay(day: String): Seq[FormError] =
+      Try(ChronoField.DAY_OF_MONTH.checkValidIntValue(day.toInt)) match {
+        case Success(_) => Nil
+        case Failure(_) => Seq(FormError(s"$key.day", s"error.day.invalid"))
+      }
 
-    val int = intFormatter(
-      requiredKey = invalidKey,
-      wholeNumberKey = invalidKey,
-      nonNumericKey = invalidKey,
-      args
-    )
+    def validateMonth(month: String): Seq[FormError] =
+      Try(ChronoField.MONTH_OF_YEAR.checkValidIntValue(month.toInt)) match {
+        case Success(_) => Nil
+        case Failure(_) => Seq(FormError(s"$key.month", s"error.month.invalid"))
+      }
 
-    for {
-      day   <- int.bind(s"$key.day", data)
-      month <- int.bind(s"$key.month", data)
-      year  <- int.bind(s"$key.year", data)
-      date  <- toDate(key, day, month, year)
-    } yield date
+    def validateYear(year: String): Seq[FormError] =
+      Try(ChronoField.YEAR.checkValidIntValue(year.toInt)) match {
+        case Success(_) => Nil
+        case Failure(_) => Seq(FormError(s"$key.year", s"error.year.invalid"))
+      }
+
+    (day, month, year) match {
+      case (Some(d), Some(m), Some(y)) => validateDay(d) ++ validateMonth(m) ++ validateYear(y)
+      case (Some(d), Some(m), None)    => validateDay(d) ++ validateMonth(m)
+      case (Some(d), None, Some(y))    => validateDay(d) ++ validateYear(y)
+      case (None, Some(m), Some(y))    => validateMonth(m) ++ validateYear(y)
+      case (None, None, Some(y))       => validateYear(y)
+      case (None, Some(m), None)       => validateMonth(m)
+      case (Some(d), None, None)       => validateDay(d)
+      case _                           => Nil
+    }
   }
 
   override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], LocalDate] = {
+    val dayKey: String   = s"$key.day"
+    val monthKey: String = s"$key.month"
+    val yearKey: String  = s"$key.year"
 
-    val fields = fieldKeys.map { field =>
-      field -> data.get(s"$key.$field").filter(_.nonEmpty)
-    }.toMap
+    val day: Option[String]   = data.get(dayKey).filter(_.nonEmpty)
+    val month: Option[String] = data.get(monthKey).filter(_.nonEmpty)
+    val year: Option[String]  = data.get(yearKey).filter(_.nonEmpty)
 
-    lazy val missingFields = fields
-      .withFilter(_._2.isEmpty)
-      .map(_._1)
-      .toList
+    val validatedDayMonthYear = validateDayMonthYear(key, day, month, year)
 
-    fields.count(_._2.isDefined) match {
-      case 3 =>
-        formatDate(key, data).left.map {
-          _.map(_.copy(key = key, args = args))
+    (day, month, year) match {
+      case (Some(day), Some(month), Some(year)) =>
+        validatedDayMonthYear match {
+          case Nil        => toDate(key, day.toInt, month.toInt, year.toInt)
+          case formErrors => Left(formErrors)
         }
-      case 2 =>
-        Left(List(FormError(key, requiredKey, missingFields ++ args)))
-      case 1 =>
-        Left(List(FormError(key, twoRequiredKey, missingFields ++ args)))
-      case _ =>
-        Left(List(FormError(key, allRequiredKey, args)))
+      case (Some(_), None, Some(_))             =>
+        Left(validatedDayMonthYear ++ Seq(FormError(monthKey, "error.month.required")))
+      case (None, Some(_), Some(_))             =>
+        Left(validatedDayMonthYear ++ Seq(FormError(dayKey, "error.day.required")))
+      case (Some(_), Some(_), None)             =>
+        Left(validatedDayMonthYear ++ Seq(FormError(yearKey, "error.year.required")))
+      case (None, None, Some(_))                =>
+        Left(validatedDayMonthYear ++ Seq("day", "month").map(f => FormError(s"$key.$f", s"error.$f.required")))
+      case (None, Some(_), None)                =>
+        Left(validatedDayMonthYear ++ Seq("day", "year").map(f => FormError(s"$key.$f", s"error.$f.required")))
+      case (Some(_), None, None)                =>
+        Left(validatedDayMonthYear ++ Seq("month", "year").map(f => FormError(s"$key.$f", s"error.$f.required")))
+      case _                                    => Left(validatedDayMonthYear ++ Seq(FormError(key, requiredKey, args)))
     }
   }
 

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/forms/mappings/LocalDateFormatter.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/forms/mappings/LocalDateFormatter.scala
@@ -83,11 +83,11 @@ private[mappings] class LocalDateFormatter(
     val month: Option[String] = data.get(monthKey).filter(_.nonEmpty)
     val year: Option[String]  = data.get(yearKey).filter(_.nonEmpty)
 
-    val validatedDayMonthYear = validateDayMonthYear(key, day, month, year)
+    val dayMonthYearErrors: Seq[FormError] = validateDayMonthYear(key, day, month, year)
 
     ((day, month, year) match {
       case (Some(day), Some(month), Some(year)) =>
-        validatedDayMonthYear match {
+        dayMonthYearErrors match {
           case Nil => toDate(key, day.toInt, month.toInt, year.toInt)
           case _   => Left(Nil)
         }
@@ -98,7 +98,7 @@ private[mappings] class LocalDateFormatter(
       case (None, Some(_), None)                => Left(Seq("day", "year").map(f => FormError(s"$key.$f", s"error.$f.required")))
       case (Some(_), None, None)                => Left(Seq("month", "year").map(f => FormError(s"$key.$f", s"error.$f.required")))
       case _                                    => Left(Seq(FormError(key, requiredKey, args)))
-    }).left.map(_ ++ validatedDayMonthYear)
+    }).left.map(_ ++ dayMonthYearErrors)
   }
 
   override def unbind(key: String, value: LocalDate): Map[String, String] =

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/forms/mappings/Mappings.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/forms/mappings/Mappings.scala
@@ -51,10 +51,14 @@ trait Mappings extends Formatters with Constraints {
 
   protected def localDate(
     invalidKey: String,
-    allRequiredKey: String,
-    twoRequiredKey: String,
     requiredKey: String,
     args: Seq[String] = Seq.empty
   ): FieldMapping[LocalDate] =
-    of(new LocalDateFormatter(invalidKey, allRequiredKey, twoRequiredKey, requiredKey, args))
+    of(
+      new LocalDateFormatter(
+        invalidKey,
+        requiredKey,
+        args
+      )
+    )
 }

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/viewmodels/govuk/ErrorSummaryFluency.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/viewmodels/govuk/ErrorSummaryFluency.scala
@@ -44,36 +44,6 @@ trait ErrorSummaryFluency {
         title = Text(messages("error.summary.title"))
       )
     }
-
-    def dateErrorSummary(
-      form: Form[_],
-      errorLinkOverrides: Map[String, String] = Map.empty
-    )(implicit messages: Messages): ErrorSummary = {
-
-      val errors = form.errors.flatMap { error =>
-        val missingFields: Seq[String] = error.args.map(_.toString)
-        if (missingFields.nonEmpty) {
-          missingFields.map { field =>
-            ErrorLink(
-              href = Some(s"#value.$field"),
-              content = Text(messages(s"error.$field.required", error.args: _*))
-            )
-          }
-        } else {
-          Seq(
-            ErrorLink(
-              href = Some(s"#${errorLinkOverrides.getOrElse(error.key, error.key)}"),
-              content = Text(messages(error.message, error.args: _*))
-            )
-          )
-        }
-      }
-
-      ErrorSummary(
-        errorList = errors,
-        title = Text(messages("error.summary.title"))
-      )
-    }
   }
 
   implicit class FluentErrorSummary(errorSummary: ErrorSummary) {

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/AmlRegulatedActivityStartDateView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/AmlRegulatedActivityStartDateView.scala.html
@@ -32,11 +32,12 @@
 ) {
     @formHelper(action = AmlRegulatedActivityStartDateController.onSubmit()) {
         @if(form.errors.nonEmpty) {
-            @errorSummary(ErrorSummaryViewModel.dateErrorSummary(form, errorLinkOverrides = Map("value" -> "value.day")))
+            @errorSummary(ErrorSummaryViewModel(form))
         }
 
         @dateInput(DateViewModel(
             field = form("value"),
+            formErrors = form.errors,
             legend = LegendViewModel(messages("amlStartDate.heading")).asPageHeading()
         )
                 .withHint(HintViewModel(messages("amlStartDate.hint")))

--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,6 @@ lazy val root = (project in file("."))
         group(
           Seq(
             "javascripts/prevent-resubmit-warning.js",
-            "javascripts/back-click.js",
             "javascripts/print-dialogue.js",
             "javascripts/accessible-autocomplete-fixes.js"
           )

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -16,6 +16,19 @@ date.day = Day
 date.month = Month
 date.year = Year
 
+date.month.1 = January
+date.month.2 = February
+date.month.3 = March
+date.month.4 = April
+date.month.5 = May
+date.month.6 = June
+date.month.7 = July
+date.month.8 = August
+date.month.9 = September
+date.month.10 = October
+date.month.11 = November
+date.month.12 = December
+
 timeout.title = You’re about to be signed out
 timeout.message = For security reasons, you will be signed out of this service in
 timeout.keepAlive = Stay signed in
@@ -23,13 +36,17 @@ timeout.signOut = Sign out
 
 error.browser.title.prefix = Error:
 error.boolean = Please give an answer
-error.invalid_date = Give a correct date
 error.day.required = Enter a day
+error.day.invalid = The day entered must be a real day
 error.month.required = Enter a month
+error.month.invalid = The month entered must be a real month
 error.year.required = Enter a year
-error.integer = Give an answer in whole numbers
-error.non_numeric = Give a value using only numbers
-error.number = Please enter a valid number
+error.year.invalid = The year entered must be a real year
+error.dayMonth.required = The date entered must include a day and month
+error.dayYear.required = The date entered must include a day and year
+error.monthYear.required = The date entered must include a month and year
+error.date.required = Enter a date
+error.date.invalid = The date entered must be a real date
 error.required = Please enter a value
 error.summary.title = There is a problem
 
@@ -129,11 +146,7 @@ amlRegulated.error.required = Select an answer
 amlStartDate.title = What date did your AML-regulated activity start?
 amlStartDate.heading = What date did your AML-regulated activity start?
 amlStartDate.hint = For example, 13 10 2022
-amlStartDate.error.invalid = Start date is invalid
-amlStartDate.error.allRequired = Enter a date
-amlStartDate.error.twoRequired = Date must include a {0} and {1}
-amlStartDate.error.required = Date must include a {0}
-amlStartDate.error.notWithinFinancialYear = The start date does not fall within the current financial year
+amlStartDate.error.notWithinFinancialYear = The date must be between 1 April {0} and 31 March {1}
 checkYourAnswers.title = Check your answers
 checkYourAnswers.heading = Check your answers
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -16,19 +16,6 @@ date.day = Day
 date.month = Month
 date.year = Year
 
-date.month.1 = January
-date.month.2 = February
-date.month.3 = March
-date.month.4 = April
-date.month.5 = May
-date.month.6 = June
-date.month.7 = July
-date.month.8 = August
-date.month.9 = September
-date.month.10 = October
-date.month.11 = November
-date.month.12 = December
-
 timeout.title = You’re about to be signed out
 timeout.message = For security reasons, you will be signed out of this service in
 timeout.keepAlive = Stay signed in

--- a/test-common/uk/gov/hmrc/economiccrimelevyregistration/EclTestData.scala
+++ b/test-common/uk/gov/hmrc/economiccrimelevyregistration/EclTestData.scala
@@ -28,7 +28,6 @@ import uk.gov.hmrc.economiccrimelevyregistration.models.grs.VerificationStatus._
 import uk.gov.hmrc.economiccrimelevyregistration.models.grs._
 
 import java.time.{Instant, LocalDate}
-import scala.util.Try
 
 case class EnrolmentsWithEcl(enrolments: Enrolments)
 
@@ -42,8 +41,6 @@ case class IncorporatedEntityJourneyDataWithSuccessfulRegistration(
   incorporatedEntityJourneyData: IncorporatedEntityJourneyData
 )
 
-case class InvalidDayMonthYear(day: String, month: String, year: String)
-
 trait EclTestData {
 
   implicit val arbInstant: Arbitrary[Instant] = Arbitrary {
@@ -52,25 +49,6 @@ trait EclTestData {
 
   implicit val arbLocalDate: Arbitrary[LocalDate] = Arbitrary {
     LocalDate.now()
-  }
-
-  implicit val arbInvalidDayMonthYear: Arbitrary[InvalidDayMonthYear] = Arbitrary {
-    def isInvalidLocalDate(dayMonthYear: (String, String, String)): Boolean = {
-      val (day, month, year) = dayMonthYear
-      Try {
-        LocalDate.of(year.toInt, month.toInt, day.toInt)
-      }.toOption.fold(true)(_ => false)
-    }
-
-    def nonEmptyString: Gen[String] = Gen.nonEmptyListOf[Char](Arbitrary.arbChar.arbitrary).map(_.mkString)
-
-    val dayMonthYearGen: Gen[(String, String, String)] = for {
-      day   <- nonEmptyString
-      month <- nonEmptyString
-      year  <- nonEmptyString
-    } yield (day, month, year)
-
-    dayMonthYearGen.retryUntil(dmy => isInvalidLocalDate(dmy)).map(s => InvalidDayMonthYear(s._1, s._2, s._3))
   }
 
   implicit val arbPartnershipType: Arbitrary[PartnershipType] = Arbitrary {

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/forms/AmlRegulatedActivityStartDateFormProviderSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/forms/AmlRegulatedActivityStartDateFormProviderSpec.scala
@@ -24,24 +24,18 @@ class AmlRegulatedActivityStartDateFormProviderSpec extends DateBehaviours {
   val form = new AmlRegulatedActivityStartDateFormProvider()()
 
   "value" should {
-    val fieldName      = "value"
-    val invalidKey     = "amlStartDate.error.invalid"
-    val allRequiredKey = "amlStartDate.error.allRequired"
-    val twoRequiredKey = "amlStartDate.error.twoRequired"
-    val requiredKey    = "amlStartDate.error.required"
+    val fieldName   = "value"
+    val requiredKey = "error.date.required"
 
     behave like dateField(
       form,
       fieldName,
-      invalidKey,
       datesBetween(EclTaxYear.currentFinancialYearStartDate, EclTaxYear.currentFinancialYearEndDate)
     )
 
     behave like mandatoryDateField(
       form,
       fieldName,
-      allRequiredKey,
-      twoRequiredKey,
       requiredKey
     )
 
@@ -49,14 +43,28 @@ class AmlRegulatedActivityStartDateFormProviderSpec extends DateBehaviours {
       form,
       fieldName,
       EclTaxYear.currentFinancialYearStartDate,
-      FormError(fieldName, "amlStartDate.error.notWithinFinancialYear")
+      FormError(
+        fieldName,
+        "amlStartDate.error.notWithinFinancialYear",
+        Seq(
+          EclTaxYear.currentFinancialYearStartDate.getYear.toString,
+          EclTaxYear.currentFinancialYearEndDate.getYear.toString
+        )
+      )
     )
 
     behave like dateFieldWithMax(
       form,
       fieldName,
       EclTaxYear.currentFinancialYearEndDate,
-      FormError(fieldName, "amlStartDate.error.notWithinFinancialYear")
+      FormError(
+        fieldName,
+        "amlStartDate.error.notWithinFinancialYear",
+        Seq(
+          EclTaxYear.currentFinancialYearStartDate.getYear.toString,
+          EclTaxYear.currentFinancialYearEndDate.getYear.toString
+        )
+      )
     )
   }
 }

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/forms/behaviours/DateBehaviours.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/forms/behaviours/DateBehaviours.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.economiccrimelevyregistration.forms.behaviours
 
 import org.scalacheck.Gen
 import play.api.data.{Form, FormError}
-import uk.gov.hmrc.economiccrimelevyregistration.{EclTestData, InvalidDayMonthYear}
+import uk.gov.hmrc.economiccrimelevyregistration.EclTestData
 
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -28,9 +28,7 @@ class DateBehaviours extends FieldBehaviours with EclTestData {
   def dateField(
     form: Form[_],
     key: String,
-    invalidKey: String,
-    validData: Gen[LocalDate],
-    errorArgs: Seq[String] = Seq.empty
+    validData: Gen[LocalDate]
   ): Unit =
     "bind" should {
       "bind valid data" in {
@@ -46,18 +44,6 @@ class DateBehaviours extends FieldBehaviours with EclTestData {
           result.value.value shouldEqual date
           result.errors         shouldBe empty
         }
-      }
-
-      "fail to bind invalid data" in forAll { invalidDayMonthYear: InvalidDayMonthYear =>
-        val data = Map(
-          s"$key.day"   -> invalidDayMonthYear.day,
-          s"$key.month" -> invalidDayMonthYear.month,
-          s"$key.year"  -> invalidDayMonthYear.year
-        )
-
-        val result = form.bind(data)
-
-        result.errors should contain only FormError(key, invalidKey, errorArgs)
       }
     }
 
@@ -104,39 +90,14 @@ class DateBehaviours extends FieldBehaviours with EclTestData {
   def mandatoryDateField(
     form: Form[_],
     key: String,
-    requiredAllKey: String,
-    twoRequiredKey: String,
     requiredKey: String,
     errorArgs: Seq[String] = Seq.empty
   ): Unit =
     "bind" should {
       "fail to bind an empty date" in {
-
         val result = form.bind(Map.empty[String, String])
 
-        result.errors should contain only FormError(key, requiredAllKey, errorArgs)
-      }
-
-      "fail to bind missing date elements" in forAll(
-        Table(
-          ("day", "month", "year", "expectedResult"),
-          ("1", "", "", Seq(FormError(key, twoRequiredKey, Seq("month", "year")))),
-          ("", "1", "", Seq(FormError(key, twoRequiredKey, Seq("day", "year")))),
-          ("", "", "2022", Seq(FormError(key, twoRequiredKey, Seq("day", "month")))),
-          ("1", "1", "", Seq(FormError(key, requiredKey, Seq("year")))),
-          ("1", "", "2022", Seq(FormError(key, requiredKey, Seq("month")))),
-          ("", "1", "2022", Seq(FormError(key, requiredKey, Seq("day"))))
-        )
-      ) { (day: String, month: String, year: String, expectedResult: Seq[FormError]) =>
-        val data = Map(
-          s"$key.day"   -> day,
-          s"$key.month" -> month,
-          s"$key.year"  -> year
-        )
-
-        val result = form.bind(data)
-
-        result.errors shouldBe expectedResult
+        result.errors should contain only FormError(key, requiredKey, errorArgs)
       }
     }
 }

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/forms/mappings/DateMappingsSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/forms/mappings/DateMappingsSpec.scala
@@ -36,10 +36,8 @@ class DateMappingsSpec
 
   val form: Form[LocalDate] = Form(
     "value" -> localDate(
-      requiredKey = "error.required",
-      allRequiredKey = "error.required.all",
-      twoRequiredKey = "error.required.two",
-      invalidKey = "error.invalid"
+      requiredKey = "error.date.required",
+      invalidKey = "error.date.invalid"
     )
   )
 
@@ -72,7 +70,7 @@ class DateMappingsSpec
 
       val result = form.bind(Map.empty[String, String])
 
-      result.errors should contain only FormError("value", "error.required.all", List.empty)
+      result.errors should contain only FormError("value", "error.date.required")
     }
 
     "fail to bind a date with a missing day" in {
@@ -89,7 +87,7 @@ class DateMappingsSpec
 
         val result = form.bind(data)
 
-        result.errors should contain only FormError("value", "error.required", List("day"))
+        result.errors should contain only FormError("value.day", "error.day.required")
       }
     }
 
@@ -105,7 +103,7 @@ class DateMappingsSpec
         val result = form.bind(data)
 
         result.errors should contain(
-          FormError("value", "error.invalid", List.empty)
+          FormError("value.day", "error.day.invalid")
         )
       }
     }
@@ -124,7 +122,7 @@ class DateMappingsSpec
 
         val result = form.bind(data)
 
-        result.errors should contain only FormError("value", "error.required", List("month"))
+        result.errors should contain only FormError("value.month", "error.month.required")
       }
     }
 
@@ -140,7 +138,7 @@ class DateMappingsSpec
         val result = form.bind(data)
 
         result.errors should contain(
-          FormError("value", "error.invalid", List.empty)
+          FormError("value.month", "error.month.invalid")
         )
       }
     }
@@ -159,7 +157,7 @@ class DateMappingsSpec
 
         val result = form.bind(data)
 
-        result.errors should contain only FormError("value", "error.required", List("year"))
+        result.errors should contain only FormError("value.year", "error.year.required")
       }
     }
 
@@ -175,7 +173,7 @@ class DateMappingsSpec
         val result = form.bind(data)
 
         result.errors should contain(
-          FormError("value", "error.invalid", List.empty)
+          FormError("value.year", "error.year.invalid", List.empty)
         )
       }
     }
@@ -198,7 +196,10 @@ class DateMappingsSpec
 
           val result = form.bind(data)
 
-          result.errors should contain only FormError("value", "error.required.two", List("day", "month"))
+          result.errors should contain theSameElementsAs Seq(
+            FormError("value.day", "error.day.required"),
+            FormError("value.month", "error.month.required")
+          )
       }
     }
 
@@ -220,7 +221,10 @@ class DateMappingsSpec
 
           val result = form.bind(data)
 
-          result.errors should contain only FormError("value", "error.required.two", List("day", "year"))
+          result.errors should contain theSameElementsAs Seq(
+            FormError("value.day", "error.day.required"),
+            FormError("value.year", "error.year.required")
+          )
       }
     }
 
@@ -242,7 +246,10 @@ class DateMappingsSpec
 
           val result = form.bind(data)
 
-          result.errors should contain only FormError("value", "error.required.two", List("month", "year"))
+          result.errors should contain theSameElementsAs Seq(
+            FormError("value.month", "error.month.required"),
+            FormError("value.year", "error.year.required")
+          )
       }
     }
 
@@ -258,7 +265,10 @@ class DateMappingsSpec
 
           val result = form.bind(data)
 
-          result.errors should contain only FormError("value", "error.invalid", List.empty)
+          result.errors should contain theSameElementsAs Seq(
+            FormError("value.day", "error.day.invalid"),
+            FormError("value.month", "error.month.invalid")
+          )
       }
     }
 
@@ -274,7 +284,10 @@ class DateMappingsSpec
 
           val result = form.bind(data)
 
-          result.errors should contain only FormError("value", "error.invalid", List.empty)
+          result.errors should contain theSameElementsAs Seq(
+            FormError("value.day", "error.day.invalid"),
+            FormError("value.year", "error.year.invalid")
+          )
       }
     }
 
@@ -290,7 +303,10 @@ class DateMappingsSpec
 
           val result = form.bind(data)
 
-          result.errors should contain only FormError("value", "error.invalid", List.empty)
+          result.errors should contain theSameElementsAs Seq(
+            FormError("value.month", "error.month.invalid"),
+            FormError("value.year", "error.year.invalid")
+          )
       }
     }
 
@@ -306,7 +322,11 @@ class DateMappingsSpec
 
           val result = form.bind(data)
 
-          result.errors should contain only FormError("value", "error.invalid", List.empty)
+          result.errors should contain theSameElementsAs Seq(
+            FormError("value.day", "error.day.invalid"),
+            FormError("value.month", "error.month.invalid"),
+            FormError("value.year", "error.year.invalid")
+          )
       }
     }
 
@@ -321,7 +341,7 @@ class DateMappingsSpec
       val result = form.bind(data)
 
       result.errors should contain(
-        FormError("value", "error.invalid", List.empty)
+        FormError("value", "error.date.invalid", List.empty)
       )
     }
 


### PR DESCRIPTION
Refactored the date validation so that it more closely aligns with how we should validate dates and present error messages according to the design system

- Removed some duplicate tests, `DateMappingsSpec` is testing invalid scenarios
- Update content to align with discussion had with Amanda (CD) and confluence page
- The order of validation is now: check for empty date -> check for incomplete date -> check the day, month and year are 'real' independently -> check the date is 'real' once valid day, month and year are provided -> check date is within the current financial year range
