### PR TITLE
Updates to date validation

### DIFF
--- a/app/uk/gov/hmrc/economiccrimelevyregistration/forms/AmlRegulatedActivityStartDateFormProvider.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/forms/AmlRegulatedActivityStartDateFormProvider.scala
@@ -17,31 +17,36 @@
 package uk.gov.hmrc.economiccrimelevyregistration.forms
 
 import play.api.data.Form
+import play.api.data.validation.Constraint
 import uk.gov.hmrc.economiccrimelevyregistration.forms.mappings.Mappings
 import uk.gov.hmrc.economiccrimelevyregistration.utils.EclTaxYear
 
 import java.time.LocalDate
 
 class AmlRegulatedActivityStartDateFormProvider extends Mappings {
+
+  val minDateConstraint: Constraint[LocalDate] = minDate(
+    EclTaxYear.currentFinancialYearStartDate,
+    "amlStartDate.error.notWithinFinancialYear",
+    EclTaxYear.currentFinancialYearStartDate.getYear.toString,
+    EclTaxYear.currentFinancialYearEndDate.getYear.toString
+  )
+
+  val maxDateConstraint: Constraint[LocalDate] = maxDate(
+    EclTaxYear.currentFinancialYearEndDate,
+    "amlStartDate.error.notWithinFinancialYear",
+    EclTaxYear.currentFinancialYearStartDate.getYear.toString,
+    EclTaxYear.currentFinancialYearEndDate.getYear.toString
+  )
+
   def apply(): Form[LocalDate] = Form(
     (
       "value",
       localDate(
         "error.date.invalid",
-        "error.date.required"
-      ).verifying(
-        minDate(
-          EclTaxYear.currentFinancialYearStartDate,
-          "amlStartDate.error.notWithinFinancialYear",
-          EclTaxYear.currentFinancialYearStartDate.getYear.toString,
-          EclTaxYear.currentFinancialYearEndDate.getYear.toString
-        ),
-        maxDate(
-          EclTaxYear.currentFinancialYearEndDate,
-          "amlStartDate.error.notWithinFinancialYear",
-          EclTaxYear.currentFinancialYearStartDate.getYear.toString,
-          EclTaxYear.currentFinancialYearEndDate.getYear.toString
-        )
+        "error.date.required",
+        Some(minDateConstraint),
+        Some(maxDateConstraint)
       )
     )
   )

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/forms/mappings/LocalDateFormatter.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/forms/mappings/LocalDateFormatter.scala
@@ -50,19 +50,19 @@ private[mappings] class LocalDateFormatter(
     def validateDay: Seq[FormError] =
       Try(ChronoField.DAY_OF_MONTH.checkValidIntValue(day.toInt)) match {
         case Success(_) => Nil
-        case Failure(_) => Seq(FormError(s"$key.day", s"error.day.invalid"))
+        case Failure(_) => Seq(FormError(s"$key.day", "error.day.invalid"))
       }
 
     def validateMonth: Seq[FormError] =
       Try(ChronoField.MONTH_OF_YEAR.checkValidIntValue(month.toInt)) match {
         case Success(_) => Nil
-        case Failure(_) => Seq(FormError(s"$key.month", s"error.month.invalid"))
+        case Failure(_) => Seq(FormError(s"$key.month", "error.month.invalid"))
       }
 
     def validateYear: Seq[FormError] =
       Try(ChronoField.YEAR.checkValidIntValue(year.toInt)) match {
         case Success(_) => Nil
-        case Failure(_) => Seq(FormError(s"$key.year", s"error.year.invalid"))
+        case Failure(_) => Seq(FormError(s"$key.year", "error.year.invalid"))
       }
 
     validateDay ++ validateMonth ++ validateYear
@@ -80,7 +80,7 @@ private[mappings] class LocalDateFormatter(
     (day, month, year) match {
       case (Some(day), Some(month), Some(year)) =>
         validateDayMonthYear(key, day, month, year) match {
-          case Nil    =>
+          case Nil          =>
             toDate(key, day.toInt, month.toInt, year.toInt) match {
               case Right(date) =>
                 val minMaxErrors = Seq(minDateConstraint, maxDateConstraint)
@@ -94,14 +94,15 @@ private[mappings] class LocalDateFormatter(
                 Either.cond(minMaxErrors.isEmpty, date, Seq(minMaxErrors.head))
               case err         => err
             }
-          case errors => Left(Seq(errors.head))
+          case error :: Nil => Left(Seq(error))
+          case _            => Left(Seq(FormError(dayKey, invalidKey)))
         }
       case (Some(_), None, Some(_))             => Left(Seq(FormError(monthKey, "error.month.required")))
       case (None, Some(_), Some(_))             => Left(Seq(FormError(dayKey, "error.day.required")))
       case (Some(_), Some(_), None)             => Left(Seq(FormError(yearKey, "error.year.required")))
       case (None, None, Some(_))                => Left(Seq(FormError(dayKey, "error.dayMonth.required")))
       case (None, Some(_), None)                => Left(Seq(FormError(dayKey, "error.dayYear.required")))
-      case (Some(_), None, None)                => Left(Seq(FormError(monthKey, s"error.monthYear.required")))
+      case (Some(_), None, None)                => Left(Seq(FormError(monthKey, "error.monthYear.required")))
       case _                                    => Left(Seq(FormError(dayKey, requiredKey, args)))
     }
   }

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/forms/mappings/Mappings.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/forms/mappings/Mappings.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.economiccrimelevyregistration.forms.mappings
 
 import play.api.data.FieldMapping
 import play.api.data.Forms.of
+import play.api.data.validation.Constraint
 import uk.gov.hmrc.economiccrimelevyregistration.models.Enumerable
 
 import java.time.LocalDate
@@ -52,12 +53,16 @@ trait Mappings extends Formatters with Constraints {
   protected def localDate(
     invalidKey: String,
     requiredKey: String,
+    minDateConstraint: Option[Constraint[LocalDate]] = None,
+    maxDateConstraint: Option[Constraint[LocalDate]] = None,
     args: Seq[String] = Seq.empty
   ): FieldMapping[LocalDate] =
     of(
       new LocalDateFormatter(
         invalidKey,
         requiredKey,
+        minDateConstraint,
+        maxDateConstraint,
         args
       )
     )

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/viewmodels/govuk/DateFluency.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/viewmodels/govuk/DateFluency.scala
@@ -18,11 +18,12 @@ package uk.gov.hmrc.economiccrimelevyregistration.viewmodels.govuk
 
 import play.api.data.{Field, FormError}
 import play.api.i18n.Messages
+import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.ErrorMessageAwareness
+import uk.gov.hmrc.govukfrontend.views.Aliases.Text
 import uk.gov.hmrc.govukfrontend.views.viewmodels.dateinput.{DateInput, InputItem}
+import uk.gov.hmrc.govukfrontend.views.viewmodels.errormessage.ErrorMessage
 import uk.gov.hmrc.govukfrontend.views.viewmodels.fieldset.{Fieldset, Legend}
 import uk.gov.hmrc.govukfrontend.views.viewmodels.hint.Hint
-import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.ErrorMessageAwareness
-import uk.gov.hmrc.govukfrontend.views.Aliases.{ErrorMessage, Text}
 
 object date extends DateFluency
 
@@ -77,19 +78,8 @@ trait DateFluency {
         fieldset = Some(fieldset),
         items = items,
         id = field.id,
-        errorMessage = (
-          formErrors.exists(_.message == "error.day.required"),
-          formErrors.exists(_.message == "error.month.required"),
-          formErrors.exists(_.message == "error.year.required")
-        ) match {
-          case (true, true, _) => Some(ErrorMessage(content = Text(messages("error.dayMonth.required"))))
-          case (true, _, true) => Some(ErrorMessage(content = Text(messages("error.dayYear.required"))))
-          case (_, true, true) => Some(ErrorMessage(content = Text(messages("error.monthYear.required"))))
-          case (true, _, _)    => Some(ErrorMessage(content = Text(messages("error.day.required"))))
-          case (_, true, _)    => Some(ErrorMessage(content = Text(messages("error.month.required"))))
-          case (_, _, true)    => Some(ErrorMessage(content = Text(messages("error.year.required"))))
-          case _               => formErrors.headOption.map(err => ErrorMessage(content = Text(messages(err.message, err.args: _*))))
-        }
+        errorMessage =
+          formErrors.headOption.map(err => ErrorMessage(content = Text(messages(err.message, err.args: _*))))
       )
     }
   }

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -87,7 +87,7 @@
     </check>
     <check level="warning" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
         <parameters>
-            <parameter name="maximum"><![CDATA[15]]></parameter>
+            <parameter name="maximum"><![CDATA[20]]></parameter>
         </parameters>
     </check>
     <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/forms/AmlRegulatedActivityStartDateFormProviderSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/forms/AmlRegulatedActivityStartDateFormProviderSpec.scala
@@ -35,7 +35,7 @@ class AmlRegulatedActivityStartDateFormProviderSpec extends DateBehaviours {
 
     behave like mandatoryDateField(
       form,
-      fieldName,
+      s"$fieldName.day",
       requiredKey
     )
 
@@ -44,7 +44,7 @@ class AmlRegulatedActivityStartDateFormProviderSpec extends DateBehaviours {
       fieldName,
       EclTaxYear.currentFinancialYearStartDate,
       FormError(
-        fieldName,
+        s"$fieldName.day",
         "amlStartDate.error.notWithinFinancialYear",
         Seq(
           EclTaxYear.currentFinancialYearStartDate.getYear.toString,
@@ -58,7 +58,7 @@ class AmlRegulatedActivityStartDateFormProviderSpec extends DateBehaviours {
       fieldName,
       EclTaxYear.currentFinancialYearEndDate,
       FormError(
-        fieldName,
+        s"$fieldName.day",
         "amlStartDate.error.notWithinFinancialYear",
         Seq(
           EclTaxYear.currentFinancialYearStartDate.getYear.toString,

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/forms/mappings/DateMappingsSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/forms/mappings/DateMappingsSpec.scala
@@ -250,7 +250,7 @@ class DateMappingsSpec
 
           val result = form.bind(data)
 
-          result.errors should contain only FormError("value.day", "error.day.invalid")
+          result.errors should contain only FormError("value.day", "error.date.invalid")
       }
     }
 
@@ -266,7 +266,7 @@ class DateMappingsSpec
 
           val result = form.bind(data)
 
-          result.errors should contain only FormError("value.day", "error.day.invalid")
+          result.errors should contain only FormError("value.day", "error.date.invalid")
       }
     }
 
@@ -282,7 +282,7 @@ class DateMappingsSpec
 
           val result = form.bind(data)
 
-          result.errors should contain only FormError("value.month", "error.month.invalid")
+          result.errors should contain only FormError("value.day", "error.date.invalid")
       }
     }
 
@@ -298,7 +298,7 @@ class DateMappingsSpec
 
           val result = form.bind(data)
 
-          result.errors should contain only FormError("value.day", "error.day.invalid")
+          result.errors should contain only FormError("value.day", "error.date.invalid")
       }
     }
 

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/forms/mappings/DateMappingsSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/forms/mappings/DateMappingsSpec.scala
@@ -70,7 +70,7 @@ class DateMappingsSpec
 
       val result = form.bind(Map.empty[String, String])
 
-      result.errors should contain only FormError("value", "error.date.required")
+      result.errors should contain only FormError("value.day", "error.date.required")
     }
 
     "fail to bind a date with a missing day" in {
@@ -102,9 +102,7 @@ class DateMappingsSpec
 
         val result = form.bind(data)
 
-        result.errors should contain(
-          FormError("value.day", "error.day.invalid")
-        )
+        result.errors should contain only FormError("value.day", "error.day.invalid")
       }
     }
 
@@ -137,9 +135,7 @@ class DateMappingsSpec
 
         val result = form.bind(data)
 
-        result.errors should contain(
-          FormError("value.month", "error.month.invalid")
-        )
+        result.errors should contain only FormError("value.month", "error.month.invalid")
       }
     }
 
@@ -172,9 +168,7 @@ class DateMappingsSpec
 
         val result = form.bind(data)
 
-        result.errors should contain(
-          FormError("value.year", "error.year.invalid", List.empty)
-        )
+        result.errors should contain only FormError("value.year", "error.year.invalid", List.empty)
       }
     }
 
@@ -196,10 +190,7 @@ class DateMappingsSpec
 
           val result = form.bind(data)
 
-          result.errors should contain theSameElementsAs Seq(
-            FormError("value.day", "error.day.required"),
-            FormError("value.month", "error.month.required")
-          )
+          result.errors should contain only FormError("value.day", "error.dayMonth.required")
       }
     }
 
@@ -221,10 +212,7 @@ class DateMappingsSpec
 
           val result = form.bind(data)
 
-          result.errors should contain theSameElementsAs Seq(
-            FormError("value.day", "error.day.required"),
-            FormError("value.year", "error.year.required")
-          )
+          result.errors should contain only FormError("value.day", "error.dayYear.required")
       }
     }
 
@@ -246,10 +234,7 @@ class DateMappingsSpec
 
           val result = form.bind(data)
 
-          result.errors should contain theSameElementsAs Seq(
-            FormError("value.month", "error.month.required"),
-            FormError("value.year", "error.year.required")
-          )
+          result.errors should contain only FormError("value.month", "error.monthYear.required")
       }
     }
 
@@ -265,10 +250,7 @@ class DateMappingsSpec
 
           val result = form.bind(data)
 
-          result.errors should contain theSameElementsAs Seq(
-            FormError("value.day", "error.day.invalid"),
-            FormError("value.month", "error.month.invalid")
-          )
+          result.errors should contain only FormError("value.day", "error.day.invalid")
       }
     }
 
@@ -284,10 +266,7 @@ class DateMappingsSpec
 
           val result = form.bind(data)
 
-          result.errors should contain theSameElementsAs Seq(
-            FormError("value.day", "error.day.invalid"),
-            FormError("value.year", "error.year.invalid")
-          )
+          result.errors should contain only FormError("value.day", "error.day.invalid")
       }
     }
 
@@ -303,10 +282,7 @@ class DateMappingsSpec
 
           val result = form.bind(data)
 
-          result.errors should contain theSameElementsAs Seq(
-            FormError("value.month", "error.month.invalid"),
-            FormError("value.year", "error.year.invalid")
-          )
+          result.errors should contain only FormError("value.month", "error.month.invalid")
       }
     }
 
@@ -322,11 +298,7 @@ class DateMappingsSpec
 
           val result = form.bind(data)
 
-          result.errors should contain theSameElementsAs Seq(
-            FormError("value.day", "error.day.invalid"),
-            FormError("value.month", "error.month.invalid"),
-            FormError("value.year", "error.year.invalid")
-          )
+          result.errors should contain only FormError("value.day", "error.day.invalid")
       }
     }
 
@@ -340,9 +312,7 @@ class DateMappingsSpec
 
       val result = form.bind(data)
 
-      result.errors should contain(
-        FormError("value", "error.date.invalid", List.empty)
-      )
+      result.errors should contain only FormError("value.day", "error.date.invalid", List.empty)
     }
 
     "unbind a date" in {


### PR DESCRIPTION
After discussion on Slack - it was confirmed that the error summary should only ever list 1 error for the date input, and it should be the same as the error message at the field level, which is the highest priority message.

**Summary:**

- Simplify the `LocalDateFormatter` so that it only ever returns one form error, the highest priority one.
- Move the use of the min and max date constraints so that they are optional parameters on the `LocalDateFormatter`, and apply this constraint within the `bind` instead of using `.verifying`. This is so that when we construct the form error, we can specify the exact field we want to link to for this error, `.verifying` does not allow you to specify this which is a limitation of play.
- Retained the independent validation of day, month and year which allows us to be more descriptive about which part of the date is not valid as well as link to that specific field