### PR TITLE
Cache implicit arbitraries to speed up test compilation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -106,7 +106,8 @@ val scalaCompilerOptions: Def.Setting[Task[Seq[String]]] = scalacOptions ++= Seq
   "-deprecation",
   "-rootdir",
   baseDirectory.value.getCanonicalPath,
-  "-Wconf:cat=feature:ws,cat=optimizer:ws,src=target/.*:s"
+  "-Wconf:cat=feature:ws,cat=optimizer:ws,src=target/.*:s",
+  "-Xlint:-byname-implicit"
 )
 
 addCommandAlias("runAllChecks", ";clean;compile;scalafmtCheckAll;coverage;test;it:test;scalastyle;coverageReport")

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/AddAnotherContactISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/AddAnotherContactISpec.scala
@@ -1,10 +1,11 @@
 package uk.gov.hmrc.economiccrimelevyregistration
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.{derivedArbitrary, random}
+import com.danielasfregola.randomdatagenerator.RandomDataGenerator.random
 import play.api.test.FakeRequest
 import uk.gov.hmrc.economiccrimelevyregistration.base.ISpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.behaviours.AuthorisedBehaviour
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.{contacts, routes}
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.models._
 
 class AddAnotherContactISpec extends ISpecBase with AuthorisedBehaviour {

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/AmlRegulatedActivityStartDateISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/AmlRegulatedActivityStartDateISpec.scala
@@ -1,11 +1,12 @@
 package uk.gov.hmrc.economiccrimelevyregistration
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.{derivedArbitrary, random}
+import com.danielasfregola.randomdatagenerator.RandomDataGenerator.random
 import play.api.test.FakeRequest
 import uk.gov.hmrc.economiccrimelevyregistration.base.ISpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.behaviours.AuthorisedBehaviour
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.routes
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.routes._
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.models._
 
 import java.time.LocalDate

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/AmlRegulatedISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/AmlRegulatedISpec.scala
@@ -1,11 +1,12 @@
 package uk.gov.hmrc.economiccrimelevyregistration
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.{derivedArbitrary, random}
+import com.danielasfregola.randomdatagenerator.RandomDataGenerator.random
 import play.api.test.FakeRequest
 import uk.gov.hmrc.economiccrimelevyregistration.base.ISpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.behaviours.AuthorisedBehaviour
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.routes
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.routes._
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.models._
 import uk.gov.hmrc.economiccrimelevyregistration.utils.EclTaxYear
 

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/AmlSupervisorISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/AmlSupervisorISpec.scala
@@ -1,10 +1,11 @@
 package uk.gov.hmrc.economiccrimelevyregistration
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.{derivedArbitrary, random}
+import com.danielasfregola.randomdatagenerator.RandomDataGenerator.random
 import play.api.test.FakeRequest
 import uk.gov.hmrc.economiccrimelevyregistration.base.ISpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.behaviours.AuthorisedBehaviour
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.routes
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.models._
 
 class AmlSupervisorISpec extends ISpecBase with AuthorisedBehaviour {

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/BusinessSectorISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/BusinessSectorISpec.scala
@@ -1,10 +1,11 @@
 package uk.gov.hmrc.economiccrimelevyregistration
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.{derivedArbitrary, random}
+import com.danielasfregola.randomdatagenerator.RandomDataGenerator.random
 import play.api.test.FakeRequest
 import uk.gov.hmrc.economiccrimelevyregistration.base.ISpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.behaviours.AuthorisedBehaviour
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.{contacts, routes}
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.models._
 
 class BusinessSectorISpec extends ISpecBase with AuthorisedBehaviour {

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/ConfirmContactAddressISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/ConfirmContactAddressISpec.scala
@@ -1,10 +1,11 @@
 package uk.gov.hmrc.economiccrimelevyregistration
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.{derivedArbitrary, random}
+import com.danielasfregola.randomdatagenerator.RandomDataGenerator.random
 import play.api.test.FakeRequest
 import uk.gov.hmrc.economiccrimelevyregistration.base.ISpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.behaviours.AuthorisedBehaviour
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.routes
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.models._
 
 class ConfirmContactAddressISpec extends ISpecBase with AuthorisedBehaviour {

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/EntityTypeISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/EntityTypeISpec.scala
@@ -1,10 +1,11 @@
 package uk.gov.hmrc.economiccrimelevyregistration
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.{derivedArbitrary, random}
+import com.danielasfregola.randomdatagenerator.RandomDataGenerator.random
 import play.api.test.FakeRequest
 import uk.gov.hmrc.economiccrimelevyregistration.base.ISpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.behaviours.AuthorisedBehaviour
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.routes
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.models.EntityType._
 import uk.gov.hmrc.economiccrimelevyregistration.models._
 
@@ -28,7 +29,7 @@ class EntityTypeISpec extends ISpecBase with AuthorisedBehaviour {
     }
   }
 
-  s"POST ${routes.EntityTypeController.onSubmit().url}" should {
+  s"POST ${routes.EntityTypeController.onSubmit().url}"  should {
     behave like authorisedActionRoute(routes.EntityTypeController.onSubmit())
 
     "save the selected entity type then redirect to the GRS UK Limited Company journey when the UK Limited Company option is selected" in {

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/FirstContactEmailISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/FirstContactEmailISpec.scala
@@ -1,10 +1,11 @@
 package uk.gov.hmrc.economiccrimelevyregistration
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.{derivedArbitrary, random}
+import com.danielasfregola.randomdatagenerator.RandomDataGenerator.random
 import play.api.test.FakeRequest
 import uk.gov.hmrc.economiccrimelevyregistration.base.ISpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.behaviours.AuthorisedBehaviour
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.contacts
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.models._
 
 class FirstContactEmailISpec extends ISpecBase with AuthorisedBehaviour {

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/FirstContactNameISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/FirstContactNameISpec.scala
@@ -1,10 +1,11 @@
 package uk.gov.hmrc.economiccrimelevyregistration
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.{derivedArbitrary, random}
+import com.danielasfregola.randomdatagenerator.RandomDataGenerator.random
 import play.api.test.FakeRequest
 import uk.gov.hmrc.economiccrimelevyregistration.base.ISpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.behaviours.AuthorisedBehaviour
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.contacts
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.models._
 
 class FirstContactNameISpec extends ISpecBase with AuthorisedBehaviour {

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/FirstContactNumberISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/FirstContactNumberISpec.scala
@@ -1,10 +1,11 @@
 package uk.gov.hmrc.economiccrimelevyregistration
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.{derivedArbitrary, random}
+import com.danielasfregola.randomdatagenerator.RandomDataGenerator.random
 import play.api.test.FakeRequest
 import uk.gov.hmrc.economiccrimelevyregistration.base.ISpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.behaviours.AuthorisedBehaviour
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.contacts
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.models._
 
 class FirstContactNumberISpec extends ISpecBase with AuthorisedBehaviour {

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/FirstContactRoleISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/FirstContactRoleISpec.scala
@@ -1,10 +1,11 @@
 package uk.gov.hmrc.economiccrimelevyregistration
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.{derivedArbitrary, random}
+import com.danielasfregola.randomdatagenerator.RandomDataGenerator.random
 import play.api.test.FakeRequest
 import uk.gov.hmrc.economiccrimelevyregistration.base.ISpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.behaviours.AuthorisedBehaviour
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.contacts
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.models._
 
 class FirstContactRoleISpec extends ISpecBase with AuthorisedBehaviour {

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/GrsContinueISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/GrsContinueISpec.scala
@@ -1,10 +1,11 @@
 package uk.gov.hmrc.economiccrimelevyregistration
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.{derivedArbitrary, random}
+import com.danielasfregola.randomdatagenerator.RandomDataGenerator.random
 import play.api.test.FakeRequest
 import uk.gov.hmrc.economiccrimelevyregistration.base.ISpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.behaviours.AuthorisedBehaviour
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.routes
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.models.EclSubscriptionStatus._
 import uk.gov.hmrc.economiccrimelevyregistration.models.EntityType._
 import uk.gov.hmrc.economiccrimelevyregistration.models.grs.{IncorporatedEntityJourneyData, PartnershipEntityJourneyData, SoleTraderEntityJourneyData}
@@ -103,7 +104,9 @@ class GrsContinueISpec extends ISpecBase with AuthorisedBehaviour {
 
       status(result) shouldBe OK
 
-      contentAsString(result) shouldBe s"Business is already subscribed to ECL with registration reference $testEclRegistrationReference"
+      contentAsString(
+        result
+      ) shouldBe s"Business is already subscribed to ECL with registration reference $testEclRegistrationReference"
     }
 
     "retrieve the sole trader entity GRS journey data, update the registration with the GRS journey data and handle the GRS/BV response to continue the registration journey" in {
@@ -185,7 +188,9 @@ class GrsContinueISpec extends ISpecBase with AuthorisedBehaviour {
 
       status(result) shouldBe OK
 
-      contentAsString(result) shouldBe s"Business is already subscribed to ECL with registration reference $testEclRegistrationReference"
+      contentAsString(
+        result
+      ) shouldBe s"Business is already subscribed to ECL with registration reference $testEclRegistrationReference"
     }
 
     "retrieve the partnership entity GRS journey data, update the registration with the GRS journey data and handle the GRS/BV response to continue the registration journey" in {
@@ -233,7 +238,7 @@ class GrsContinueISpec extends ISpecBase with AuthorisedBehaviour {
     "retrieve the partnership entity GRS journey data, update the registration with the GRS journey data and handle the GRS/BV response where already registered" in {
       stubAuthorisedWithNoGroupEnrolment()
 
-      val entityType = random[PartnershipType].entityType
+      val entityType   = random[PartnershipType].entityType
       val registration =
         random[Registration]
           .copy(
@@ -269,7 +274,9 @@ class GrsContinueISpec extends ISpecBase with AuthorisedBehaviour {
 
       status(result) shouldBe OK
 
-      contentAsString(result) shouldBe s"Business is already subscribed to ECL with registration reference $testEclRegistrationReference"
+      contentAsString(
+        result
+      ) shouldBe s"Business is already subscribed to ECL with registration reference $testEclRegistrationReference"
     }
   }
 

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/IsUkAddressISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/IsUkAddressISpec.scala
@@ -1,10 +1,11 @@
 package uk.gov.hmrc.economiccrimelevyregistration
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.{derivedArbitrary, random}
+import com.danielasfregola.randomdatagenerator.RandomDataGenerator.random
 import play.api.test.FakeRequest
 import uk.gov.hmrc.economiccrimelevyregistration.base.ISpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.behaviours.AuthorisedBehaviour
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.routes
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.models._
 
 class IsUkAddressISpec extends ISpecBase with AuthorisedBehaviour {

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/RegisterWithOtherAmlSupervisorISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/RegisterWithOtherAmlSupervisorISpec.scala
@@ -16,11 +16,12 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.{derivedArbitrary, random}
+import com.danielasfregola.randomdatagenerator.RandomDataGenerator.random
 import play.api.test.FakeRequest
 import uk.gov.hmrc.economiccrimelevyregistration.base.ISpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.behaviours.AuthorisedBehaviour
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.routes
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.models.AmlSupervisorType._
 import uk.gov.hmrc.economiccrimelevyregistration.models.{AmlSupervisor, Registration}
 

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/SecondContactEmailISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/SecondContactEmailISpec.scala
@@ -1,10 +1,11 @@
 package uk.gov.hmrc.economiccrimelevyregistration
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.{derivedArbitrary, random}
+import com.danielasfregola.randomdatagenerator.RandomDataGenerator.random
 import play.api.test.FakeRequest
 import uk.gov.hmrc.economiccrimelevyregistration.base.ISpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.behaviours.AuthorisedBehaviour
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.contacts
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.models._
 
 class SecondContactEmailISpec extends ISpecBase with AuthorisedBehaviour {

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/SecondContactNameISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/SecondContactNameISpec.scala
@@ -1,10 +1,11 @@
 package uk.gov.hmrc.economiccrimelevyregistration
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.{derivedArbitrary, random}
+import com.danielasfregola.randomdatagenerator.RandomDataGenerator.random
 import play.api.test.FakeRequest
 import uk.gov.hmrc.economiccrimelevyregistration.base.ISpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.behaviours.AuthorisedBehaviour
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.contacts
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.models._
 
 class SecondContactNameISpec extends ISpecBase with AuthorisedBehaviour {
@@ -29,14 +30,14 @@ class SecondContactNameISpec extends ISpecBase with AuthorisedBehaviour {
     }
   }
 
-  s"POST ${contacts.routes.SecondContactNameController.onSubmit().url}" should {
+  s"POST ${contacts.routes.SecondContactNameController.onSubmit().url}"  should {
     behave like authorisedActionRoute(contacts.routes.SecondContactNameController.onSubmit())
 
     "save the provided name then redirect to the second contact role page" in {
       stubAuthorisedWithNoGroupEnrolment()
 
       val registration = random[Registration]
-      val name = stringsWithMaxLength(nameMaxLength).sample.get
+      val name         = stringsWithMaxLength(nameMaxLength).sample.get
 
       stubGetRegistration(registration)
 

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/SecondContactNumberISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/SecondContactNumberISpec.scala
@@ -1,10 +1,11 @@
 package uk.gov.hmrc.economiccrimelevyregistration
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.{derivedArbitrary, random}
+import com.danielasfregola.randomdatagenerator.RandomDataGenerator.random
 import play.api.test.FakeRequest
 import uk.gov.hmrc.economiccrimelevyregistration.base.ISpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.behaviours.AuthorisedBehaviour
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.{contacts, routes}
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.models._
 
 class SecondContactNumberISpec extends ISpecBase with AuthorisedBehaviour {

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/SecondContactRoleISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/SecondContactRoleISpec.scala
@@ -1,10 +1,11 @@
 package uk.gov.hmrc.economiccrimelevyregistration
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.{derivedArbitrary, random}
+import com.danielasfregola.randomdatagenerator.RandomDataGenerator.random
 import play.api.test.FakeRequest
 import uk.gov.hmrc.economiccrimelevyregistration.base.ISpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.behaviours.AuthorisedBehaviour
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.contacts
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.models._
 
 class SecondContactRoleISpec extends ISpecBase with AuthorisedBehaviour {

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/UkRevenueISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/UkRevenueISpec.scala
@@ -1,13 +1,14 @@
 package uk.gov.hmrc.economiccrimelevyregistration
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.{derivedArbitrary, random}
+import com.danielasfregola.randomdatagenerator.RandomDataGenerator.random
 import play.api.test.FakeRequest
 import uk.gov.hmrc.economiccrimelevyregistration.base.ISpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.behaviours.AuthorisedBehaviour
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.routes
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.routes._
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.models._
 import uk.gov.hmrc.economiccrimelevyregistration.utils.EclTaxYear
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.routes._
 
 class UkRevenueISpec extends ISpecBase with AuthorisedBehaviour {
 

--- a/test-common/uk/gov/hmrc/economiccrimelevyregistration/generators/CachedArbitraries.scala
+++ b/test-common/uk/gov/hmrc/economiccrimelevyregistration/generators/CachedArbitraries.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.economiccrimelevyregistration.generators
+
+import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import org.scalacheck.Arbitrary
+import org.scalacheck.derive.MkArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.EclTestData
+import uk.gov.hmrc.economiccrimelevyregistration.models.eacd.GroupEnrolmentsResponse
+import uk.gov.hmrc.economiccrimelevyregistration.models.grs.{GrsCreateJourneyResponse, IncorporatedEntityJourneyData, PartnershipEntityJourneyData, RegistrationStatus, SoleTraderEntityJourneyData, VerificationStatus}
+import uk.gov.hmrc.economiccrimelevyregistration.models.{AmlSupervisorType, BusinessSector, EclSubscriptionStatus, EntityType, Registration, SubscriptionStatus}
+
+object CachedArbitraries extends EclTestData {
+
+  def mkArb[T](implicit mkArb: MkArbitrary[T]): Arbitrary[T] = MkArbitrary[T].arbitrary
+
+  implicit lazy val arbRegistration: Arbitrary[Registration]                                   = mkArb
+  implicit lazy val arbBusinessSector: Arbitrary[BusinessSector]                               = mkArb
+  implicit lazy val arbVerificationStatus: Arbitrary[VerificationStatus]                       = mkArb
+  implicit lazy val arbRegistrationStatus: Arbitrary[RegistrationStatus]                       = mkArb
+  implicit lazy val arbSubscriptionStatus: Arbitrary[SubscriptionStatus]                       = mkArb
+  implicit lazy val arbEntityType: Arbitrary[EntityType]                                       = mkArb
+  implicit lazy val arbAmlSupervisorType: Arbitrary[AmlSupervisorType]                         = mkArb
+  implicit lazy val arbIncorporatedEntityJourneyData: Arbitrary[IncorporatedEntityJourneyData] = mkArb
+  implicit lazy val arbPartnershipEntityJourneyData: Arbitrary[PartnershipEntityJourneyData]   = mkArb
+  implicit lazy val arbSoleTraderEntityJourneyData: Arbitrary[SoleTraderEntityJourneyData]     = mkArb
+  implicit lazy val arbGrsCreateJourneyResponse: Arbitrary[GrsCreateJourneyResponse]           = mkArb
+  implicit lazy val arbGroupEnrolmentsResponse: Arbitrary[GroupEnrolmentsResponse]             = mkArb
+  implicit lazy val arbEclSubscriptionStatus: Arbitrary[EclSubscriptionStatus]                 = mkArb
+
+}

--- a/test-common/uk/gov/hmrc/economiccrimelevyregistration/generators/CachedArbitraries.scala
+++ b/test-common/uk/gov/hmrc/economiccrimelevyregistration/generators/CachedArbitraries.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.economiccrimelevyregistration.models.{AmlSupervisorType, Busi
 
 object CachedArbitraries extends EclTestData {
 
-  def mkArb[T](implicit mkArb: MkArbitrary[T]): Arbitrary[T] = MkArbitrary[T].arbitrary
+  private def mkArb[T](implicit mkArb: MkArbitrary[T]): Arbitrary[T] = MkArbitrary[T].arbitrary
 
   implicit lazy val arbRegistration: Arbitrary[Registration]                                   = mkArb
   implicit lazy val arbBusinessSector: Arbitrary[BusinessSector]                               = mkArb

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/EclRegistrationConnectorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/EclRegistrationConnectorSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.connectors
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import play.api.http.Status.NO_CONTENT

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/EnrolmentStoreProxyConnectorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/EnrolmentStoreProxyConnectorSpec.scala
@@ -21,7 +21,7 @@ import org.mockito.ArgumentMatchers.any
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.models.eacd.GroupEnrolmentsResponse
 import uk.gov.hmrc.http.HttpClient
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 
 import scala.concurrent.Future
 

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/IncorporatedEntityIdentificationFrontendConnectorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/IncorporatedEntityIdentificationFrontendConnectorSpec.scala
@@ -21,7 +21,7 @@ import org.mockito.ArgumentMatchers.any
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.models.grs._
 import uk.gov.hmrc.http.HttpClient
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 
 import scala.concurrent.Future
 

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/PartnershipIdentificationFrontendConnectorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/PartnershipIdentificationFrontendConnectorSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.connectors
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import uk.gov.hmrc.economiccrimelevyregistration.PartnershipType

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/SoleTraderIdentificationFrontendConnectorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/SoleTraderIdentificationFrontendConnectorSpec.scala
@@ -21,7 +21,7 @@ import org.mockito.ArgumentMatchers.any
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.models.grs._
 import uk.gov.hmrc.http.HttpClient
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 
 import scala.concurrent.Future
 

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/AmlRegulatedActivityStartDateControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/AmlRegulatedActivityStartDateControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.controllers
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import play.api.data.Form

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/AmlRegulatedControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/AmlRegulatedControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.controllers
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import play.api.data.Form

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/AmlSupervisorControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/AmlSupervisorControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.controllers
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.scalacheck.Arbitrary

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/BusinessSectorControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/BusinessSectorControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.controllers
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import play.api.data.Form

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/CheckYourAnswersControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/CheckYourAnswersControllerSpec.scala
@@ -16,13 +16,13 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.controllers
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
 import play.api.mvc.Result
 import play.api.test.Helpers._
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.models.Registration
 import uk.gov.hmrc.economiccrimelevyregistration.views.html.CheckYourAnswersView
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryList
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 
 import scala.concurrent.Future
 

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/ConfirmContactAddressControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/ConfirmContactAddressControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.controllers
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import play.api.data.Form

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/EntityTypeControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/EntityTypeControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.controllers
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import play.api.data.Form

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/GrsContinueControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/GrsContinueControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.controllers
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import play.api.mvc.Result

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/IsUkAddressControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/IsUkAddressControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.controllers
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import play.api.data.Form

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegisterWithOtherAmlSupervisorControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegisterWithOtherAmlSupervisorControllerSpec.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.controllers
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
 import play.api.http.Status.OK
 import play.api.mvc.Result
 import play.api.test.Helpers.{contentAsString, status}
@@ -24,6 +23,7 @@ import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.models.AmlSupervisorType._
 import uk.gov.hmrc.economiccrimelevyregistration.models.{AmlSupervisor, Registration}
 import uk.gov.hmrc.economiccrimelevyregistration.views.html.{FinancialConductAuthorityView, GamblingCommissionView}
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 
 import scala.concurrent.Future
 

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/UkRevenueControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/UkRevenueControllerSpec.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.controllers
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import play.api.data.Form
@@ -29,6 +28,7 @@ import uk.gov.hmrc.economiccrimelevyregistration.forms.UkRevenueFormProvider
 import uk.gov.hmrc.economiccrimelevyregistration.models.Registration
 import uk.gov.hmrc.economiccrimelevyregistration.navigation.UkRevenuePageNavigator
 import uk.gov.hmrc.economiccrimelevyregistration.views.html.UkRevenueView
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 
 import scala.concurrent.Future
 

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/actions/AuthorisedActionSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/actions/AuthorisedActionSpec.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.controllers.actions
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import play.api.mvc.{BodyParsers, Request, Result}

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/actions/DataRetrievalActionSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/actions/DataRetrievalActionSpec.scala
@@ -16,13 +16,13 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.controllers.actions
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
 import org.mockito.ArgumentMatchers.any
 import play.api.mvc.{AnyContentAsEmpty, Request, Result}
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.models.Registration
 import uk.gov.hmrc.economiccrimelevyregistration.models.requests.{AuthorisedRequest, RegistrationDataRequest}
 import uk.gov.hmrc.economiccrimelevyregistration.services.EclRegistrationService
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 
 import scala.concurrent.Future
 

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/AddAnotherContactControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/AddAnotherContactControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.controllers.contacts
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import play.api.data.Form

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/FirstContactEmailControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/FirstContactEmailControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.controllers.contacts
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.scalacheck.Arbitrary

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/FirstContactNameControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/FirstContactNameControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.controllers.contacts
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.scalacheck.Arbitrary

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/FirstContactNumberControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/FirstContactNumberControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.controllers.contacts
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.scalacheck.Arbitrary

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/FirstContactRoleControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/FirstContactRoleControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.controllers.contacts
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.scalacheck.Arbitrary

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/SecondContactEmailControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/SecondContactEmailControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.controllers.contacts
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.scalacheck.Arbitrary

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/SecondContactNameControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/SecondContactNameControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.controllers.contacts
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.scalacheck.Arbitrary

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/SecondContactNumberControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/SecondContactNumberControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.controllers.contacts
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.scalacheck.Arbitrary

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/SecondContactRoleControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/SecondContactRoleControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.controllers.contacts
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.scalacheck.Arbitrary

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/models/AmlSupervisorTypeSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/models/AmlSupervisorTypeSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.models
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import play.api.libs.json.{JsBoolean, JsError, JsString, Json}
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/models/BusinessSectorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/models/BusinessSectorSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.models
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import play.api.libs.json.{JsBoolean, JsError, JsString, Json}
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/models/EntityTypeSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/models/EntityTypeSpec.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.economiccrimelevyregistration.models
 
 import play.api.libs.json.{JsBoolean, JsError, JsString, Json}
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 
 class EntityTypeSpec extends SpecBase {
   "writes" should {

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/models/SubscriptionStatusSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/models/SubscriptionStatusSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.models
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import play.api.libs.json._
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.models.EclSubscriptionStatus._

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/models/grs/RegistrationStatusSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/models/grs/RegistrationStatusSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.models.grs
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import play.api.libs.json.{JsBoolean, JsError, JsString, Json}
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.models.grs.RegistrationStatus._

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/models/grs/VerificationStatusSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/models/grs/VerificationStatusSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.models.grs
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import play.api.libs.json.{JsBoolean, JsError, JsString, Json}
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.models.grs.VerificationStatus._

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/AmlRegulatedActivityStartDatePageNavigatorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/AmlRegulatedActivityStartDatePageNavigatorSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.navigation
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.routes
 import uk.gov.hmrc.economiccrimelevyregistration.models.{NormalMode, Registration}

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/AmlRegulatedPageNavigatorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/AmlRegulatedPageNavigatorSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.navigation
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.routes
 import uk.gov.hmrc.economiccrimelevyregistration.models.{NormalMode, Registration}

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/AmlSupervisorPageNavigatorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/AmlSupervisorPageNavigatorSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.navigation
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import org.scalacheck.Gen
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.routes

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/BusinessSectorPageNavigatorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/BusinessSectorPageNavigatorSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.navigation
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.{contacts, routes}
 import uk.gov.hmrc.economiccrimelevyregistration.models.{BusinessSector, NormalMode, Registration}

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/ConfirmContactAddressPageNavigatorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/ConfirmContactAddressPageNavigatorSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.navigation
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import uk.gov.hmrc.economiccrimelevyregistration.IncorporatedEntityJourneyDataWithValidCompanyProfile

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/EntityTypePageNavigatorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/EntityTypePageNavigatorSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.navigation
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import play.api.mvc.Call

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/IsUkAddressPageNavigatorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/IsUkAddressPageNavigatorSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.navigation
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.IncorporatedEntityJourneyDataWithValidCompanyProfile
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.{contacts, routes}

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/UkRevenuePageNavigatorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/UkRevenuePageNavigatorSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.navigation
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.routes
 import uk.gov.hmrc.economiccrimelevyregistration.models.{NormalMode, Registration}

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/contacts/AddAnotherContactPageNavigatorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/contacts/AddAnotherContactPageNavigatorSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.navigation.contacts
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.IncorporatedEntityJourneyDataWithValidCompanyProfile
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.{contacts, routes}

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/contacts/FirstContactEmailPageNavigatorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/contacts/FirstContactEmailPageNavigatorSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.navigation.contacts
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.contacts.routes
 import uk.gov.hmrc.economiccrimelevyregistration.models.{NormalMode, Registration}

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/contacts/FirstContactNamePageNavigatorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/contacts/FirstContactNamePageNavigatorSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.navigation.contacts
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.contacts.routes
 import uk.gov.hmrc.economiccrimelevyregistration.models.{NormalMode, Registration}

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/contacts/FirstContactNumberPageNavigatorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/contacts/FirstContactNumberPageNavigatorSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.navigation.contacts
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.contacts.routes
 import uk.gov.hmrc.economiccrimelevyregistration.models.{NormalMode, Registration}

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/contacts/FirstContactRolePageNavigatorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/contacts/FirstContactRolePageNavigatorSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.navigation.contacts
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.models.{NormalMode, Registration}
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.contacts.routes

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/contacts/SecondContactEmailPageNavigatorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/contacts/SecondContactEmailPageNavigatorSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.navigation.contacts
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.contacts.routes
 import uk.gov.hmrc.economiccrimelevyregistration.models.{NormalMode, Registration}

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/contacts/SecondContactNamePageNavigatorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/contacts/SecondContactNamePageNavigatorSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.navigation.contacts
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.contacts.routes
 import uk.gov.hmrc.economiccrimelevyregistration.models.{NormalMode, Registration}

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/contacts/SecondContactNumberPageNavigatorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/contacts/SecondContactNumberPageNavigatorSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.navigation.contacts
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.IncorporatedEntityJourneyDataWithValidCompanyProfile
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.routes

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/contacts/SecondContactRolePageNavigatorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/navigation/contacts/SecondContactRolePageNavigatorSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.navigation.contacts
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.contacts.routes
 import uk.gov.hmrc.economiccrimelevyregistration.models.{NormalMode, Registration}

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/services/EclRegistrationServiceSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/services/EclRegistrationServiceSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.services
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import org.mockito.ArgumentMatchers.any
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.connectors.EclRegistrationConnector


### PR DESCRIPTION
Importing `derivedArbitrary` everywhere for test data generation is causing the tests to take ~5 minutes to compile, and it was getting worse the more data / code we added. This fixes it by effectively caching only a single instance of the implicit arbitraries that can be used throughout the tests.