### PR TITLE
Added telephone number and email address constraints

### DIFF
--- a/app/uk/gov/hmrc/economiccrimelevyregistration/forms/contacts/FirstContactEmailFormProvider.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/forms/contacts/FirstContactEmailFormProvider.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.economiccrimelevyregistration.forms.contacts
 
 import play.api.data.Form
-import uk.gov.hmrc.economiccrimelevyregistration.forms.mappings.{Mappings, Regex}
+import uk.gov.hmrc.economiccrimelevyregistration.forms.mappings.Mappings
 
 import javax.inject.Inject
 
@@ -28,7 +28,6 @@ class FirstContactEmailFormProvider @Inject() extends Mappings {
   def apply(): Form[String] =
     Form(
       "value" -> text("firstContactEmail.error.required")
-        .verifying(maxLength(maxLength, "firstContactEmail.error.length"))
-        .verifying(regexp(Regex.emailRegex, "firstContactEmail.error.invalid"))
+        .verifying(emailAddress(maxLength, "firstContactEmail.error.length", "firstContactEmail.error.invalid"))
     )
 }

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/forms/contacts/FirstContactNumberFormProvider.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/forms/contacts/FirstContactNumberFormProvider.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.economiccrimelevyregistration.forms.contacts
 
 import play.api.data.Form
-import uk.gov.hmrc.economiccrimelevyregistration.forms.mappings.{Mappings, Regex}
+import uk.gov.hmrc.economiccrimelevyregistration.forms.mappings.Mappings
 
 import javax.inject.Inject
 
@@ -28,8 +28,7 @@ class FirstContactNumberFormProvider @Inject() extends Mappings {
   def apply(): Form[String] =
     Form(
       "value" -> text("firstContactNumber.error.required")
-        .verifying(maxLength(maxLength, "firstContactNumber.error.length"))
-        .verifying(regexp(Regex.telephoneNumberRegex, "firstContactNumber.error.invalid"))
+        .verifying(telephoneNumber(maxLength, "firstContactNumber.error.length", "firstContactNumber.error.invalid"))
     )
 
 }

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/forms/contacts/SecondContactEmailFormProvider.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/forms/contacts/SecondContactEmailFormProvider.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.economiccrimelevyregistration.forms.contacts
 
 import play.api.data.Form
-import uk.gov.hmrc.economiccrimelevyregistration.forms.mappings.{Mappings, Regex}
+import uk.gov.hmrc.economiccrimelevyregistration.forms.mappings.Mappings
 
 import javax.inject.Inject
 
@@ -28,7 +28,6 @@ class SecondContactEmailFormProvider @Inject() extends Mappings {
   def apply(): Form[String] =
     Form(
       "value" -> text("secondContactEmail.error.required")
-        .verifying(maxLength(maxLength, "secondContactEmail.error.length"))
-        .verifying(regexp(Regex.emailRegex, "secondContactEmail.error.invalid"))
+        .verifying(emailAddress(maxLength, "secondContactEmail.error.length", "secondContactEmail.error.invalid"))
     )
 }

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/forms/contacts/SecondContactNumberFormProvider.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/forms/contacts/SecondContactNumberFormProvider.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.economiccrimelevyregistration.forms.contacts
 
 import play.api.data.Form
-import uk.gov.hmrc.economiccrimelevyregistration.forms.mappings.{Mappings, Regex}
+import uk.gov.hmrc.economiccrimelevyregistration.forms.mappings.Mappings
 
 import javax.inject.Inject
 
@@ -28,8 +28,7 @@ class SecondContactNumberFormProvider @Inject() extends Mappings {
   def apply(): Form[String] =
     Form(
       "value" -> text("secondContactNumber.error.required")
-        .verifying(maxLength(maxLength, "secondContactNumber.error.length"))
-        .verifying(regexp(Regex.telephoneNumberRegex, "secondContactNumber.error.invalid"))
+        .verifying(telephoneNumber(maxLength, "secondContactNumber.error.length", "secondContactNumber.error.invalid"))
     )
 
 }

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/forms/mappings/Constraints.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/forms/mappings/Constraints.scala
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.economiccrimelevyregistration.forms.mappings
 
 import java.time.LocalDate
-
 import play.api.data.validation.{Constraint, Invalid, Valid}
 
 trait Constraints {
@@ -102,4 +101,19 @@ trait Constraints {
       case _                   =>
         Invalid(errorKey)
     }
+
+  protected def telephoneNumber(max: Int, maxLengthKey: String, invalidKey: String): Constraint[String] = Constraint {
+    s =>
+      maxLength(max, maxLengthKey)(s) match {
+        case Valid   => regexp(Regex.telephoneNumberRegex, invalidKey)(s)
+        case invalid => invalid
+      }
+  }
+
+  protected def emailAddress(max: Int, maxLengthKey: String, invalidKey: String): Constraint[String] = Constraint { s =>
+    maxLength(max, maxLengthKey)(s) match {
+      case Valid   => regexp(Regex.emailRegex, invalidKey)(s)
+      case invalid => invalid
+    }
+  }
 }

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -153,27 +153,27 @@ firstContactName.legend.p1 = Provide the name of a person in your organisation w
 firstContactName.legend.p2 = You can add a second contact name and their details after you have added the first contact.
 firstContactName.hint = For example, ''John Jones'' or ''Laura Smith''.
 firstContactName.error.required = Enter a full name
-firstContactName.error.length = Full name must be 160 characters or less
+firstContactName.error.length = Full name must be {0} characters or less
 
 firstContactRole.title = What is {0}''s role?
 firstContactRole.heading = What is {0}''s role?
 firstContactRole.legend = Tell us about their role in your organisation.
 firstContactRole.hint = For example, ''Compliance officer''.
 firstContactRole.error.required = Enter a role
-firstContactRole.error.length = Role must be 60 characters or less
+firstContactRole.error.length = Role must be {0} characters or less
 
 firstContactEmail.title = What is {0}''s email address?
 firstContactEmail.heading = What is {0}''s email address?
 firstContactEmail.legend = This is the email address of your named contact.
 firstContactEmail.error.required = Enter an email address
-firstContactEmail.error.length = Email address must be 160 characters or less
+firstContactEmail.error.length = Email address must be {0} characters or less
 firstContactEmail.error.invalid = Enter an email address in the correct format, like name@example.com
 
 firstContactNumber.title = What is {0}''s telephone number?
 firstContactNumber.heading = What is {0}''s telephone number?
 firstContactNumber.legend = This is the telephone number of your named contact.
 firstContactNumber.error.required = Enter a telephone number
-firstContactNumber.error.length = Telephone number must be 24 characters or less
+firstContactNumber.error.length = Telephone number must be {0} characters or less
 firstContactNumber.error.invalid = Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192
 
 addAnotherContact.title = Would you like to add another contact?
@@ -186,27 +186,27 @@ secondContactName.heading = Provide a second contact name
 secondContactName.legend = Add the details of one more contact within your organisation.
 secondContactName.hint = For example, ''John Jones'' or ''Laura Smith''.
 secondContactName.error.required = Enter a full name
-secondContactName.error.length = Full name must be 160 characters or less
+secondContactName.error.length = Full name must be {0} characters or less
 
 secondContactRole.title = What is {0}''s role?
 secondContactRole.heading = What is {0}''s role?
 secondContactRole.legend = Tell us about their role in your organisation.
 secondContactRole.hint = For example, ''Compliance officer''.
 secondContactRole.error.required = Enter a role
-secondContactRole.error.length = Role must be 60 characters or less
+secondContactRole.error.length = Role must be {0} characters or less
 
 secondContactEmail.title = What is {0}''s email address?
 secondContactEmail.heading = What is {0}''s email address?
 secondContactEmail.legend = This is the email address of your named contact.
 secondContactEmail.error.required = Enter an email address
-secondContactEmail.error.length = Email address must be 160 characters or less
+secondContactEmail.error.length = Email address must be {0} characters or less
 secondContactEmail.error.invalid = Enter an email address in the correct format, like name@example.com
 
 secondContactNumber.title = What is {0}''s telephone number?
 secondContactNumber.heading = What is {0}''s telephone number?
 secondContactNumber.legend = This is the telephone number of your named contact.
 secondContactNumber.error.required = Enter a telephone number
-secondContactNumber.error.length = Telephone number must be 24 characters or less
+secondContactNumber.error.length = Telephone number must be {0} characters or less
 secondContactNumber.error.invalid = Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192
 
 confirmContactAddress.title = Do you want to use this registered address as the main contact address?

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/forms/behaviours/StringFieldBehaviours.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/forms/behaviours/StringFieldBehaviours.scala
@@ -26,7 +26,7 @@ trait StringFieldBehaviours extends FieldBehaviours {
 
         forAll(stringsLongerThan(maxLength) -> "longString") { string =>
           val result = form.bind(Map(fieldName -> string)).apply(fieldName)
-          result.errors should contain(lengthError)
+          result.errors should contain only lengthError
         }
       }
     }

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/forms/contacts/FirstContactNumberFormProviderSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/forms/contacts/FirstContactNumberFormProviderSpec.scala
@@ -56,7 +56,7 @@ class FirstContactNumberFormProviderSpec extends StringFieldBehaviours {
     ) { invalidNumber: String =>
       val result: Form[String] = form.bind(Map("value" -> invalidNumber))
 
-      result.errors.map(_.message) should contain("firstContactNumber.error.invalid")
+      result.errors.map(_.message) should contain only "firstContactNumber.error.invalid"
     }
   }
 }

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/forms/mappings/ConstraintsSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/forms/mappings/ConstraintsSpec.scala
@@ -179,4 +179,32 @@ class ConstraintsSpec extends AnyWordSpec with Matchers with ScalaCheckPropertyC
       }
     }
   }
+
+  "telephoneNumber" should {
+    "return invalid when the telephone number is too long" in forAll(stringsLongerThan(24)) { s: String =>
+      val result = telephoneNumber(24, "error.length", "error.invalid")(s)
+      result shouldEqual Invalid("error.length", 24)
+    }
+
+    "return invalid when the telephone number is not valid" in forAll(
+      stringsWithMaxLength(24).retryUntil(s => !s.matches(Regex.telephoneNumberRegex))
+    ) { s: String =>
+      val result = telephoneNumber(24, "error.length", "error.invalid")(s)
+      result shouldEqual Invalid("error.invalid", Regex.telephoneNumberRegex)
+    }
+  }
+
+  "emailAddress" should {
+    "return invalid when the email address is too long" in forAll(stringsLongerThan(160)) { s: String =>
+      val result = emailAddress(160, "error.length", "error.invalid")(s)
+      result shouldEqual Invalid("error.length", 160)
+    }
+
+    "return invalid when the email address is not valid" in forAll(
+      stringsWithMaxLength(160).retryUntil(s => !s.matches(Regex.emailRegex))
+    ) { s: String =>
+      val result = emailAddress(160, "error.length", "error.invalid")(s)
+      result shouldEqual Invalid("error.invalid", Regex.emailRegex)
+    }
+  }
 }


### PR DESCRIPTION
In testing, it was found that multiple errors were displaying in the error summary for a single field. For example when the phone number is both invalid and too long, 2 errors were displaying, which is not correct behaviour, only the highest priority error should display. This fixes that so that there is only a single constraint for telephone number and email address where only one form error is produced at a time.