### PR TITLE
Update to not check for enrolment on registration submitted

### DIFF
--- a/app/uk/gov/hmrc/economiccrimelevyregistration/config/Module.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/config/Module.scala
@@ -31,8 +31,6 @@ class Module(environment: Environment, configuration: Configuration) extends Abs
       .to(classOf[RegistrationDataRetrievalAction])
       .asEagerSingleton()
 
-    bind(classOf[AuthorisedAction]).to(classOf[BaseAuthorisedAction]).asEagerSingleton()
-
     bind(classOf[ValidatedRegistrationAction]).to(classOf[ValidatedRegistrationActionImpl]).asEagerSingleton()
 
     bind(classOf[Clock]).toInstance(Clock.systemDefaultZone.withZone(ZoneOffset.UTC))

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/AddressLookupContinueController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/AddressLookupContinueController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.economiccrimelevyregistration.controllers
 
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.economiccrimelevyregistration.connectors.{AddressLookupFrontendConnector, EclRegistrationConnector}
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedAction, DataRetrievalAction}
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedActionWithEnrolmentCheck, DataRetrievalAction}
 import uk.gov.hmrc.economiccrimelevyregistration.models.EclAddress
 import uk.gov.hmrc.economiccrimelevyregistration.models.addresslookup.AlfAddressData
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
@@ -29,7 +29,7 @@ import scala.concurrent.ExecutionContext
 @Singleton
 class AddressLookupContinueController @Inject() (
   val controllerComponents: MessagesControllerComponents,
-  authorise: AuthorisedAction,
+  authorise: AuthorisedActionWithEnrolmentCheck,
   getRegistrationData: DataRetrievalAction,
   addressLookupFrontendConnector: AddressLookupFrontendConnector,
   eclRegistrationConnector: EclRegistrationConnector

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/AmlRegulatedActivityController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/AmlRegulatedActivityController.scala
@@ -20,7 +20,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.economiccrimelevyregistration.connectors._
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedAction, DataRetrievalAction}
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedActionWithEnrolmentCheck, DataRetrievalAction}
 import uk.gov.hmrc.economiccrimelevyregistration.forms.AmlRegulatedActivityFormProvider
 import uk.gov.hmrc.economiccrimelevyregistration.forms.FormImplicits._
 import uk.gov.hmrc.economiccrimelevyregistration.models.NormalMode
@@ -34,7 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class AmlRegulatedActivityController @Inject() (
   val controllerComponents: MessagesControllerComponents,
-  authorise: AuthorisedAction,
+  authorise: AuthorisedActionWithEnrolmentCheck,
   getRegistrationData: DataRetrievalAction,
   eclRegistrationConnector: EclRegistrationConnector,
   formProvider: AmlRegulatedActivityFormProvider,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/AmlSupervisorController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/AmlSupervisorController.scala
@@ -21,7 +21,7 @@ import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.economiccrimelevyregistration.config.AppConfig
 import uk.gov.hmrc.economiccrimelevyregistration.connectors._
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedAction, DataRetrievalAction}
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedActionWithEnrolmentCheck, DataRetrievalAction}
 import uk.gov.hmrc.economiccrimelevyregistration.forms.AmlSupervisorFormProvider
 import uk.gov.hmrc.economiccrimelevyregistration.forms.FormImplicits._
 import uk.gov.hmrc.economiccrimelevyregistration.models._
@@ -35,7 +35,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class AmlSupervisorController @Inject() (
   val controllerComponents: MessagesControllerComponents,
-  authorise: AuthorisedAction,
+  authorise: AuthorisedActionWithEnrolmentCheck,
   getRegistrationData: DataRetrievalAction,
   eclRegistrationConnector: EclRegistrationConnector,
   formProvider: AmlSupervisorFormProvider,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/BusinessSectorController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/BusinessSectorController.scala
@@ -20,7 +20,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.economiccrimelevyregistration.connectors.EclRegistrationConnector
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedAction, DataRetrievalAction}
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedActionWithEnrolmentCheck, DataRetrievalAction}
 import uk.gov.hmrc.economiccrimelevyregistration.forms.BusinessSectorFormProvider
 import uk.gov.hmrc.economiccrimelevyregistration.forms.FormImplicits.FormOps
 import uk.gov.hmrc.economiccrimelevyregistration.models.{BusinessSector, Mode}
@@ -34,7 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class BusinessSectorController @Inject() (
   val controllerComponents: MessagesControllerComponents,
-  authorise: AuthorisedAction,
+  authorise: AuthorisedActionWithEnrolmentCheck,
   getRegistrationData: DataRetrievalAction,
   eclRegistrationConnector: EclRegistrationConnector,
   formProvider: BusinessSectorFormProvider,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/CheckYourAnswersController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/CheckYourAnswersController.scala
@@ -20,7 +20,7 @@ import com.google.inject.Inject
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.economiccrimelevyregistration.connectors.EclRegistrationConnector
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedAction, DataRetrievalAction, ValidatedRegistrationAction}
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedActionWithEnrolmentCheck, DataRetrievalAction, ValidatedRegistrationAction}
 import uk.gov.hmrc.economiccrimelevyregistration.models.SessionKeys
 import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.checkAnswers._
 import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.govuk.summarylist._
@@ -34,7 +34,7 @@ import scala.concurrent.ExecutionContext
 @Singleton
 class CheckYourAnswersController @Inject() (
   override val messagesApi: MessagesApi,
-  authorise: AuthorisedAction,
+  authorise: AuthorisedActionWithEnrolmentCheck,
   getRegistrationData: DataRetrievalAction,
   eclRegistrationConnector: EclRegistrationConnector,
   val controllerComponents: MessagesControllerComponents,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/ConfirmContactAddressController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/ConfirmContactAddressController.scala
@@ -20,7 +20,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.economiccrimelevyregistration.connectors.EclRegistrationConnector
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedAction, DataRetrievalAction}
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedActionWithEnrolmentCheck, DataRetrievalAction}
 import uk.gov.hmrc.economiccrimelevyregistration.forms.ConfirmContactAddressFormProvider
 import uk.gov.hmrc.economiccrimelevyregistration.forms.FormImplicits.FormOps
 import uk.gov.hmrc.economiccrimelevyregistration.models.requests.RegistrationDataRequest
@@ -36,7 +36,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class ConfirmContactAddressController @Inject() (
   val controllerComponents: MessagesControllerComponents,
-  authorise: AuthorisedAction,
+  authorise: AuthorisedActionWithEnrolmentCheck,
   getRegistrationData: DataRetrievalAction,
   eclRegistrationConnector: EclRegistrationConnector,
   formProvider: ConfirmContactAddressFormProvider,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/EntityTypeController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/EntityTypeController.scala
@@ -20,7 +20,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.economiccrimelevyregistration.connectors._
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedAction, DataRetrievalAction}
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedActionWithEnrolmentCheck, DataRetrievalAction}
 import uk.gov.hmrc.economiccrimelevyregistration.forms.EntityTypeFormProvider
 import uk.gov.hmrc.economiccrimelevyregistration.forms.FormImplicits.FormOps
 import uk.gov.hmrc.economiccrimelevyregistration.models._
@@ -34,7 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class EntityTypeController @Inject() (
   val controllerComponents: MessagesControllerComponents,
-  authorise: AuthorisedAction,
+  authorise: AuthorisedActionWithEnrolmentCheck,
   getRegistrationData: DataRetrievalAction,
   eclRegistrationConnector: EclRegistrationConnector,
   formProvider: EntityTypeFormProvider,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/GrsContinueController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/GrsContinueController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.economiccrimelevyregistration.controllers
 
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import uk.gov.hmrc.economiccrimelevyregistration.connectors._
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedAction, DataRetrievalAction}
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedActionWithEnrolmentCheck, DataRetrievalAction}
 import uk.gov.hmrc.economiccrimelevyregistration.models.EclSubscriptionStatus._
 import uk.gov.hmrc.economiccrimelevyregistration.models.EntityType._
 import uk.gov.hmrc.economiccrimelevyregistration.models._
@@ -35,7 +35,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class GrsContinueController @Inject() (
   val controllerComponents: MessagesControllerComponents,
-  authorise: AuthorisedAction,
+  authorise: AuthorisedActionWithEnrolmentCheck,
   getRegistrationData: DataRetrievalAction,
   incorporatedEntityIdentificationFrontendConnector: IncorporatedEntityIdentificationFrontendConnector,
   soleTraderIdentificationFrontendConnector: SoleTraderIdentificationFrontendConnector,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/IsUkAddressController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/IsUkAddressController.scala
@@ -20,7 +20,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.economiccrimelevyregistration.connectors._
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedAction, DataRetrievalAction}
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedActionWithEnrolmentCheck, DataRetrievalAction}
 import uk.gov.hmrc.economiccrimelevyregistration.forms.FormImplicits._
 import uk.gov.hmrc.economiccrimelevyregistration.forms.IsUkAddressFormProvider
 import uk.gov.hmrc.economiccrimelevyregistration.models.NormalMode
@@ -34,7 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class IsUkAddressController @Inject() (
   val controllerComponents: MessagesControllerComponents,
-  authorise: AuthorisedAction,
+  authorise: AuthorisedActionWithEnrolmentCheck,
   getRegistrationData: DataRetrievalAction,
   eclRegistrationConnector: EclRegistrationConnector,
   formProvider: IsUkAddressFormProvider,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/JourneyRecoveryController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/JourneyRecoveryController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.economiccrimelevyregistration.controllers
 
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedAction, DataRetrievalAction}
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedActionWithEnrolmentCheck, DataRetrievalAction}
 import uk.gov.hmrc.economiccrimelevyregistration.views.html.JourneyRecoveryView
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 
@@ -27,7 +27,7 @@ import javax.inject.{Inject, Singleton}
 @Singleton
 class JourneyRecoveryController @Inject() (
   val controllerComponents: MessagesControllerComponents,
-  authorise: AuthorisedAction,
+  authorise: AuthorisedActionWithEnrolmentCheck,
   getRegistrationData: DataRetrievalAction,
   view: JourneyRecoveryView
 ) extends FrontendBaseController

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/NotLiableController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/NotLiableController.scala
@@ -18,16 +18,16 @@ package uk.gov.hmrc.economiccrimelevyregistration.controllers
 
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedAction, DataRetrievalAction}
-import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedActionWithEnrolmentCheck, DataRetrievalAction}
 import uk.gov.hmrc.economiccrimelevyregistration.views.html.NotLiableView
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 
 import javax.inject.{Inject, Singleton}
 
 @Singleton
 class NotLiableController @Inject() (
   val controllerComponents: MessagesControllerComponents,
-  authorise: AuthorisedAction,
+  authorise: AuthorisedActionWithEnrolmentCheck,
   view: NotLiableView,
   getRegistrationData: DataRetrievalAction
 ) extends FrontendBaseController

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegisterWithOtherAmlSupervisorController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegisterWithOtherAmlSupervisorController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.economiccrimelevyregistration.controllers
 
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedAction, DataRetrievalAction}
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedActionWithEnrolmentCheck, DataRetrievalAction}
 import uk.gov.hmrc.economiccrimelevyregistration.models.AmlSupervisor
 import uk.gov.hmrc.economiccrimelevyregistration.models.AmlSupervisorType.{FinancialConductAuthority, GamblingCommission}
 import uk.gov.hmrc.economiccrimelevyregistration.views.html.{FinancialConductAuthorityView, GamblingCommissionView}
@@ -29,7 +29,7 @@ import javax.inject.{Inject, Singleton}
 @Singleton
 class RegisterWithOtherAmlSupervisorController @Inject() (
   val controllerComponents: MessagesControllerComponents,
-  authorise: AuthorisedAction,
+  authorise: AuthorisedActionWithEnrolmentCheck,
   getRegistrationData: DataRetrievalAction,
   gcView: GamblingCommissionView,
   fcaView: FinancialConductAuthorityView

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationSubmittedController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationSubmittedController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.economiccrimelevyregistration.controllers
 
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.AuthorisedAction
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.AuthorisedActionWithoutEnrolmentCheck
 import uk.gov.hmrc.economiccrimelevyregistration.models.SessionKeys
 import uk.gov.hmrc.economiccrimelevyregistration.views.html.RegistrationSubmittedView
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
@@ -28,7 +28,7 @@ import javax.inject.{Inject, Singleton}
 @Singleton
 class RegistrationSubmittedController @Inject() (
   val controllerComponents: MessagesControllerComponents,
-  authorise: AuthorisedAction,
+  authorise: AuthorisedActionWithoutEnrolmentCheck,
   view: RegistrationSubmittedView
 ) extends FrontendBaseController
     with I18nSupport {

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/RelevantAp12MonthsController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/RelevantAp12MonthsController.scala
@@ -20,7 +20,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.economiccrimelevyregistration.connectors._
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedAction, DataRetrievalAction}
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedActionWithEnrolmentCheck, DataRetrievalAction}
 import uk.gov.hmrc.economiccrimelevyregistration.forms.FormImplicits._
 import uk.gov.hmrc.economiccrimelevyregistration.forms.RelevantAp12MonthsFormProvider
 import uk.gov.hmrc.economiccrimelevyregistration.models.NormalMode
@@ -34,7 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class RelevantAp12MonthsController @Inject() (
   val controllerComponents: MessagesControllerComponents,
-  authorise: AuthorisedAction,
+  authorise: AuthorisedActionWithEnrolmentCheck,
   getRegistrationData: DataRetrievalAction,
   eclRegistrationConnector: EclRegistrationConnector,
   formProvider: RelevantAp12MonthsFormProvider,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/RelevantApLengthController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/RelevantApLengthController.scala
@@ -20,7 +20,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.economiccrimelevyregistration.connectors.EclRegistrationConnector
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedAction, DataRetrievalAction}
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedActionWithEnrolmentCheck, DataRetrievalAction}
 import uk.gov.hmrc.economiccrimelevyregistration.forms.FormImplicits.FormOps
 import uk.gov.hmrc.economiccrimelevyregistration.forms.RelevantApLengthFormProvider
 import uk.gov.hmrc.economiccrimelevyregistration.models.NormalMode
@@ -34,7 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class RelevantApLengthController @Inject() (
   val controllerComponents: MessagesControllerComponents,
-  authorise: AuthorisedAction,
+  authorise: AuthorisedActionWithEnrolmentCheck,
   getRegistrationData: DataRetrievalAction,
   eclRegistrationConnector: EclRegistrationConnector,
   formProvider: RelevantApLengthFormProvider,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/SignOutController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/SignOutController.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.economiccrimelevyregistration.controllers
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.economiccrimelevyregistration.config.AppConfig
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.AuthorisedAction
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.AuthorisedActionWithoutEnrolmentCheck
 import uk.gov.hmrc.economiccrimelevyregistration.views.html.SignedOutView
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 
@@ -29,7 +29,7 @@ import javax.inject.{Inject, Singleton}
 class SignOutController @Inject() (
   val controllerComponents: MessagesControllerComponents,
   config: AppConfig,
-  authorise: AuthorisedAction,
+  authorise: AuthorisedActionWithoutEnrolmentCheck,
   view: SignedOutView
 ) extends FrontendBaseController
     with I18nSupport {

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/UkRevenueController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/UkRevenueController.scala
@@ -20,7 +20,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.economiccrimelevyregistration.connectors.EclRegistrationConnector
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedAction, DataRetrievalAction}
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedActionWithEnrolmentCheck, DataRetrievalAction}
 import uk.gov.hmrc.economiccrimelevyregistration.forms.FormImplicits.FormOps
 import uk.gov.hmrc.economiccrimelevyregistration.forms.UkRevenueFormProvider
 import uk.gov.hmrc.economiccrimelevyregistration.models.NormalMode
@@ -34,7 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class UkRevenueController @Inject() (
   val controllerComponents: MessagesControllerComponents,
-  authorise: AuthorisedAction,
+  authorise: AuthorisedActionWithEnrolmentCheck,
   getRegistrationData: DataRetrievalAction,
   eclRegistrationConnector: EclRegistrationConnector,
   formProvider: UkRevenueFormProvider,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/actions/AuthorisedAction.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/actions/AuthorisedAction.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.controllers.actions
 
-import com.google.inject.Inject
+import com.google.inject.{ImplementedBy, Inject}
 import play.api.mvc.Results._
 import play.api.mvc._
 import uk.gov.hmrc.auth.core.AffinityGroup.Agent
@@ -36,7 +36,35 @@ trait AuthorisedAction
     with FrontendHeaderCarrierProvider
     with ActionFunction[Request, AuthorisedRequest]
 
-class BaseAuthorisedAction @Inject() (
+@ImplementedBy(classOf[AuthorisedActionWithoutEnrolmentCheckImpl])
+trait AuthorisedActionWithoutEnrolmentCheck extends AuthorisedAction
+
+@ImplementedBy(classOf[AuthorisedActionWithEnrolmentCheckImpl])
+trait AuthorisedActionWithEnrolmentCheck extends AuthorisedAction
+
+class AuthorisedActionWithoutEnrolmentCheckImpl @Inject() (
+  override val authConnector: AuthConnector,
+  enrolmentStoreProxyService: EnrolmentStoreProxyService,
+  config: AppConfig,
+  override val parser: BodyParsers.Default
+)(override implicit val executionContext: ExecutionContext)
+    extends BaseAuthorisedAction(authConnector, enrolmentStoreProxyService, config, parser)
+    with AuthorisedActionWithoutEnrolmentCheck {
+  override val checkForEclEnrolment: Boolean = false
+}
+
+class AuthorisedActionWithEnrolmentCheckImpl @Inject() (
+  override val authConnector: AuthConnector,
+  enrolmentStoreProxyService: EnrolmentStoreProxyService,
+  config: AppConfig,
+  override val parser: BodyParsers.Default
+)(override implicit val executionContext: ExecutionContext)
+    extends BaseAuthorisedAction(authConnector, enrolmentStoreProxyService, config, parser)
+    with AuthorisedActionWithEnrolmentCheck {
+  override val checkForEclEnrolment: Boolean = true
+}
+
+abstract class BaseAuthorisedAction @Inject() (
   override val authConnector: AuthConnector,
   enrolmentStoreProxyService: EnrolmentStoreProxyService,
   config: AppConfig,
@@ -45,6 +73,8 @@ class BaseAuthorisedAction @Inject() (
     extends AuthorisedAction
     with FrontendHeaderCarrierProvider
     with AuthorisedFunctions {
+
+  val checkForEclEnrolment: Boolean
 
   override def invokeBlock[A](request: Request[A], block: AuthorisedRequest[A] => Future[Result]): Future[Result] =
     authorised().retrieve(internalId and allEnrolments and groupIdentifier and affinityGroup and credentialRole) {

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/AddAnotherContactController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/AddAnotherContactController.scala
@@ -20,7 +20,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.economiccrimelevyregistration.connectors._
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedAction, DataRetrievalAction}
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedActionWithEnrolmentCheck, DataRetrievalAction}
 import uk.gov.hmrc.economiccrimelevyregistration.forms.FormImplicits._
 import uk.gov.hmrc.economiccrimelevyregistration.forms.contacts.AddAnotherContactFormProvider
 import uk.gov.hmrc.economiccrimelevyregistration.models.{Contacts, NormalMode}
@@ -34,7 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class AddAnotherContactController @Inject() (
   val controllerComponents: MessagesControllerComponents,
-  authorise: AuthorisedAction,
+  authorise: AuthorisedActionWithEnrolmentCheck,
   getRegistrationData: DataRetrievalAction,
   eclRegistrationConnector: EclRegistrationConnector,
   formProvider: AddAnotherContactFormProvider,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/FirstContactEmailController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/FirstContactEmailController.scala
@@ -20,7 +20,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.economiccrimelevyregistration.connectors.EclRegistrationConnector
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedAction, DataRetrievalAction}
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedActionWithEnrolmentCheck, DataRetrievalAction}
 import uk.gov.hmrc.economiccrimelevyregistration.forms.FormImplicits.FormOps
 import uk.gov.hmrc.economiccrimelevyregistration.forms.contacts.FirstContactEmailFormProvider
 import uk.gov.hmrc.economiccrimelevyregistration.models.{Contacts, NormalMode}
@@ -34,7 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class FirstContactEmailController @Inject() (
   val controllerComponents: MessagesControllerComponents,
-  authorise: AuthorisedAction,
+  authorise: AuthorisedActionWithEnrolmentCheck,
   getRegistrationData: DataRetrievalAction,
   eclRegistrationConnector: EclRegistrationConnector,
   formProvider: FirstContactEmailFormProvider,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/FirstContactNameController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/FirstContactNameController.scala
@@ -20,7 +20,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.economiccrimelevyregistration.connectors.EclRegistrationConnector
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedAction, DataRetrievalAction}
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedActionWithEnrolmentCheck, DataRetrievalAction}
 import uk.gov.hmrc.economiccrimelevyregistration.forms.FormImplicits.FormOps
 import uk.gov.hmrc.economiccrimelevyregistration.forms.contacts.FirstContactNameFormProvider
 import uk.gov.hmrc.economiccrimelevyregistration.models.{Contacts, NormalMode}
@@ -34,7 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class FirstContactNameController @Inject() (
   val controllerComponents: MessagesControllerComponents,
-  authorise: AuthorisedAction,
+  authorise: AuthorisedActionWithEnrolmentCheck,
   getRegistrationData: DataRetrievalAction,
   eclRegistrationConnector: EclRegistrationConnector,
   formProvider: FirstContactNameFormProvider,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/FirstContactNumberController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/FirstContactNumberController.scala
@@ -20,7 +20,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.economiccrimelevyregistration.connectors.EclRegistrationConnector
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedAction, DataRetrievalAction}
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedActionWithEnrolmentCheck, DataRetrievalAction}
 import uk.gov.hmrc.economiccrimelevyregistration.forms.FormImplicits.FormOps
 import uk.gov.hmrc.economiccrimelevyregistration.forms.contacts.FirstContactNumberFormProvider
 import uk.gov.hmrc.economiccrimelevyregistration.models.{Contacts, NormalMode}
@@ -34,7 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class FirstContactNumberController @Inject() (
   val controllerComponents: MessagesControllerComponents,
-  authorise: AuthorisedAction,
+  authorise: AuthorisedActionWithEnrolmentCheck,
   getRegistrationData: DataRetrievalAction,
   eclRegistrationConnector: EclRegistrationConnector,
   formProvider: FirstContactNumberFormProvider,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/FirstContactRoleController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/FirstContactRoleController.scala
@@ -20,7 +20,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.economiccrimelevyregistration.connectors.EclRegistrationConnector
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedAction, DataRetrievalAction}
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedActionWithEnrolmentCheck, DataRetrievalAction}
 import uk.gov.hmrc.economiccrimelevyregistration.forms.FormImplicits.FormOps
 import uk.gov.hmrc.economiccrimelevyregistration.forms.contacts.FirstContactRoleFormProvider
 import uk.gov.hmrc.economiccrimelevyregistration.models.{Contacts, NormalMode}
@@ -34,7 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class FirstContactRoleController @Inject() (
   val controllerComponents: MessagesControllerComponents,
-  authorise: AuthorisedAction,
+  authorise: AuthorisedActionWithEnrolmentCheck,
   getRegistrationData: DataRetrievalAction,
   eclRegistrationConnector: EclRegistrationConnector,
   formProvider: FirstContactRoleFormProvider,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/SecondContactEmailController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/SecondContactEmailController.scala
@@ -20,7 +20,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.economiccrimelevyregistration.connectors.EclRegistrationConnector
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedAction, DataRetrievalAction}
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedActionWithEnrolmentCheck, DataRetrievalAction}
 import uk.gov.hmrc.economiccrimelevyregistration.forms.FormImplicits.FormOps
 import uk.gov.hmrc.economiccrimelevyregistration.forms.contacts.SecondContactEmailFormProvider
 import uk.gov.hmrc.economiccrimelevyregistration.models.{Contacts, NormalMode}
@@ -34,7 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class SecondContactEmailController @Inject() (
   val controllerComponents: MessagesControllerComponents,
-  authorise: AuthorisedAction,
+  authorise: AuthorisedActionWithEnrolmentCheck,
   getRegistrationData: DataRetrievalAction,
   eclRegistrationConnector: EclRegistrationConnector,
   formProvider: SecondContactEmailFormProvider,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/SecondContactNameController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/SecondContactNameController.scala
@@ -20,7 +20,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.economiccrimelevyregistration.connectors.EclRegistrationConnector
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedAction, DataRetrievalAction}
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedActionWithEnrolmentCheck, DataRetrievalAction}
 import uk.gov.hmrc.economiccrimelevyregistration.forms.FormImplicits.FormOps
 import uk.gov.hmrc.economiccrimelevyregistration.forms.contacts.SecondContactNameFormProvider
 import uk.gov.hmrc.economiccrimelevyregistration.models.{Contacts, NormalMode}
@@ -34,7 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class SecondContactNameController @Inject() (
   val controllerComponents: MessagesControllerComponents,
-  authorise: AuthorisedAction,
+  authorise: AuthorisedActionWithEnrolmentCheck,
   getRegistrationData: DataRetrievalAction,
   eclRegistrationConnector: EclRegistrationConnector,
   formProvider: SecondContactNameFormProvider,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/SecondContactNumberController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/SecondContactNumberController.scala
@@ -20,7 +20,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.economiccrimelevyregistration.connectors.EclRegistrationConnector
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedAction, DataRetrievalAction}
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedActionWithEnrolmentCheck, DataRetrievalAction}
 import uk.gov.hmrc.economiccrimelevyregistration.forms.FormImplicits.FormOps
 import uk.gov.hmrc.economiccrimelevyregistration.forms.contacts.SecondContactNumberFormProvider
 import uk.gov.hmrc.economiccrimelevyregistration.models.{Contacts, NormalMode}
@@ -34,7 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class SecondContactNumberController @Inject() (
   val controllerComponents: MessagesControllerComponents,
-  authorise: AuthorisedAction,
+  authorise: AuthorisedActionWithEnrolmentCheck,
   getRegistrationData: DataRetrievalAction,
   eclRegistrationConnector: EclRegistrationConnector,
   formProvider: SecondContactNumberFormProvider,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/SecondContactRoleController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/SecondContactRoleController.scala
@@ -20,7 +20,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.economiccrimelevyregistration.connectors.EclRegistrationConnector
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedAction, DataRetrievalAction}
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedActionWithEnrolmentCheck, DataRetrievalAction}
 import uk.gov.hmrc.economiccrimelevyregistration.forms.FormImplicits.FormOps
 import uk.gov.hmrc.economiccrimelevyregistration.forms.contacts.SecondContactRoleFormProvider
 import uk.gov.hmrc.economiccrimelevyregistration.models.{Contacts, NormalMode}
@@ -34,7 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class SecondContactRoleController @Inject() (
   val controllerComponents: MessagesControllerComponents,
-  authorise: AuthorisedAction,
+  authorise: AuthorisedActionWithEnrolmentCheck,
   getRegistrationData: DataRetrievalAction,
   eclRegistrationConnector: EclRegistrationConnector,
   formProvider: SecondContactRoleFormProvider,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/testonly/controllers/TestOnlyController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/testonly/controllers/TestOnlyController.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.economiccrimelevyregistration.testonly.controllers
 
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedAction, DataRetrievalAction}
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedActionWithoutEnrolmentCheck, DataRetrievalAction}
 import uk.gov.hmrc.economiccrimelevyregistration.testonly.connectors.TestOnlyConnector
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 
@@ -28,7 +28,7 @@ import scala.concurrent.ExecutionContext
 @Singleton
 class TestOnlyController @Inject() (
   val controllerComponents: MessagesControllerComponents,
-  authorise: AuthorisedAction,
+  authorise: AuthorisedActionWithoutEnrolmentCheck,
   getRegistrationData: DataRetrievalAction,
   testOnlyConnector: TestOnlyConnector
 )(implicit val ec: ExecutionContext)

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/testonly/controllers/stubs/StubAlfJourneyDataController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/testonly/controllers/stubs/StubAlfJourneyDataController.scala
@@ -20,7 +20,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedAction, DataRetrievalAction}
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedActionWithEnrolmentCheck, DataRetrievalAction}
 import uk.gov.hmrc.economiccrimelevyregistration.models.addresslookup.{AlfAddress, AlfAddressData, AlfCountry}
 import uk.gov.hmrc.economiccrimelevyregistration.testonly.forms.AlfStubFormProvider
 import uk.gov.hmrc.economiccrimelevyregistration.testonly.models.AlfStubFormData
@@ -33,7 +33,7 @@ import javax.inject.{Inject, Singleton}
 @Singleton
 class StubAlfJourneyDataController @Inject() (
   val controllerComponents: MessagesControllerComponents,
-  authorise: AuthorisedAction,
+  authorise: AuthorisedActionWithEnrolmentCheck,
   getRegistrationData: DataRetrievalAction,
   alfStubFormProvider: AlfStubFormProvider,
   view: StubAlfJourneyDataView

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/testonly/controllers/stubs/StubGrsJourneyDataController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/testonly/controllers/stubs/StubGrsJourneyDataController.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.economiccrimelevyregistration.testonly.controllers.stubs
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedAction, DataRetrievalAction}
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedActionWithEnrolmentCheck, DataRetrievalAction}
 import uk.gov.hmrc.economiccrimelevyregistration.testonly.forms.GrsStubFormProvider
 import uk.gov.hmrc.economiccrimelevyregistration.testonly.models.GrsStubFormData
 import uk.gov.hmrc.economiccrimelevyregistration.testonly.views.html.StubGrsJourneyDataView
@@ -30,7 +30,7 @@ import javax.inject.{Inject, Singleton}
 @Singleton
 class StubGrsJourneyDataController @Inject() (
   val controllerComponents: MessagesControllerComponents,
-  authorise: AuthorisedAction,
+  authorise: AuthorisedActionWithEnrolmentCheck,
   getRegistrationData: DataRetrievalAction,
   grsStubFormProvider: GrsStubFormProvider,
   view: StubGrsJourneyDataView

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/AddAnotherContactISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/AddAnotherContactISpec.scala
@@ -11,7 +11,7 @@ import uk.gov.hmrc.economiccrimelevyregistration.models._
 class AddAnotherContactISpec extends ISpecBase with AuthorisedBehaviour {
 
   s"GET ${contacts.routes.AddAnotherContactController.onPageLoad().url}" should {
-    behave like authorisedActionRoute(contacts.routes.AddAnotherContactController.onPageLoad())
+    behave like authorisedActionWithEnrolmentCheckRoute(contacts.routes.AddAnotherContactController.onPageLoad())
 
     "respond with 200 status and the Add another contact HTML view" in {
       stubAuthorisedWithNoGroupEnrolment()
@@ -29,7 +29,7 @@ class AddAnotherContactISpec extends ISpecBase with AuthorisedBehaviour {
   }
 
   s"POST ${contacts.routes.AddAnotherContactController.onSubmit().url}"  should {
-    behave like authorisedActionRoute(contacts.routes.AddAnotherContactController.onSubmit())
+    behave like authorisedActionWithEnrolmentCheckRoute(contacts.routes.AddAnotherContactController.onSubmit())
 
     "save the selected answer then redirect the second contact name page when the Yes option is selected" in {
       stubAuthorisedWithNoGroupEnrolment()

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/AddressLookupContinueISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/AddressLookupContinueISpec.scala
@@ -13,7 +13,7 @@ class AddressLookupContinueISpec extends ISpecBase with AuthorisedBehaviour {
   val journeyId: String = "test-journey-id"
 
   s"GET ${routes.AddressLookupContinueController.continue(journeyId).url}" should {
-    behave like authorisedActionRoute(routes.AddressLookupContinueController.continue(journeyId))
+    behave like authorisedActionWithEnrolmentCheckRoute(routes.AddressLookupContinueController.continue(journeyId))
 
     "retrieve the ALF address data, update the registration with the address and continue the registration journey" in {
       stubAuthorisedWithNoGroupEnrolment()

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/AmlRegulatedActivityISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/AmlRegulatedActivityISpec.scala
@@ -12,7 +12,7 @@ import uk.gov.hmrc.economiccrimelevyregistration.utils.EclTaxYear
 class AmlRegulatedActivityISpec extends ISpecBase with AuthorisedBehaviour {
 
   s"GET ${routes.AmlRegulatedActivityController.onPageLoad().url}" should {
-    behave like authorisedActionRoute(routes.AmlRegulatedActivityController.onPageLoad())
+    behave like authorisedActionWithEnrolmentCheckRoute(routes.AmlRegulatedActivityController.onPageLoad())
 
     "respond with 200 status and the Aml regulated HTML view" in {
       stubAuthorisedWithNoGroupEnrolment()
@@ -35,7 +35,7 @@ class AmlRegulatedActivityISpec extends ISpecBase with AuthorisedBehaviour {
   }
 
   s"POST ${routes.AmlRegulatedActivityController.onSubmit().url}"  should {
-    behave like authorisedActionRoute(routes.AmlRegulatedActivityController.onSubmit())
+    behave like authorisedActionWithEnrolmentCheckRoute(routes.AmlRegulatedActivityController.onSubmit())
 
     "save the selected AML regulated activity option then redirect to the AML supervisor page when the Yes option is selected" in {
       stubAuthorisedWithNoGroupEnrolment()

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/AmlSupervisorISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/AmlSupervisorISpec.scala
@@ -13,7 +13,7 @@ import uk.gov.hmrc.economiccrimelevyregistration.models._
 class AmlSupervisorISpec extends ISpecBase with AuthorisedBehaviour {
 
   s"GET ${routes.AmlSupervisorController.onPageLoad().url}" should {
-    behave like authorisedActionRoute(routes.AmlSupervisorController.onPageLoad())
+    behave like authorisedActionWithEnrolmentCheckRoute(routes.AmlSupervisorController.onPageLoad())
 
     "respond with 200 status and the AML supervisor HTML view" in {
       stubAuthorisedWithNoGroupEnrolment()
@@ -31,7 +31,7 @@ class AmlSupervisorISpec extends ISpecBase with AuthorisedBehaviour {
   }
 
   s"POST ${routes.AmlSupervisorController.onSubmit().url}"  should {
-    behave like authorisedActionRoute(routes.AmlSupervisorController.onPageLoad())
+    behave like authorisedActionWithEnrolmentCheckRoute(routes.AmlSupervisorController.onPageLoad())
 
     "save the selected option then redirect to the relevant AP 12 months page when the answer is either HMRC or another professional body" in {
       stubAuthorisedWithNoGroupEnrolment()

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/BusinessSectorISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/BusinessSectorISpec.scala
@@ -11,7 +11,7 @@ import uk.gov.hmrc.economiccrimelevyregistration.models._
 class BusinessSectorISpec extends ISpecBase with AuthorisedBehaviour {
 
   s"GET ${routes.BusinessSectorController.onPageLoad(NormalMode).url}" should {
-    behave like authorisedActionRoute(routes.BusinessSectorController.onPageLoad(NormalMode))
+    behave like authorisedActionWithEnrolmentCheckRoute(routes.BusinessSectorController.onPageLoad(NormalMode))
 
     "respond with 200 status and the business sector HTML view" in {
       stubAuthorisedWithNoGroupEnrolment()
@@ -29,7 +29,7 @@ class BusinessSectorISpec extends ISpecBase with AuthorisedBehaviour {
   }
 
   s"POST ${routes.BusinessSectorController.onSubmit(NormalMode).url}"  should {
-    behave like authorisedActionRoute(routes.BusinessSectorController.onSubmit(NormalMode))
+    behave like authorisedActionWithEnrolmentCheckRoute(routes.BusinessSectorController.onSubmit(NormalMode))
 
     "save the selected business sector option then redirect to the contact name page" in {
       stubAuthorisedWithNoGroupEnrolment()

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/CheckYourAnswersISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/CheckYourAnswersISpec.scala
@@ -12,7 +12,7 @@ import uk.gov.hmrc.economiccrimelevyregistration.models.errors.DataValidationErr
 class CheckYourAnswersISpec extends ISpecBase with AuthorisedBehaviour {
 
   s"GET ${routes.CheckYourAnswersController.onPageLoad().url}" should {
-    behave like authorisedActionRoute(routes.CheckYourAnswersController.onPageLoad())
+    behave like authorisedActionWithEnrolmentCheckRoute(routes.CheckYourAnswersController.onPageLoad())
 
     "respond with 200 status and the Check your answers HTML view when the registration data is valid" in {
       stubAuthorisedWithNoGroupEnrolment()
@@ -48,7 +48,7 @@ class CheckYourAnswersISpec extends ISpecBase with AuthorisedBehaviour {
   }
 
   s"POST ${routes.CheckYourAnswersController.onSubmit().url}"  should {
-    behave like authorisedActionRoute(routes.CheckYourAnswersController.onSubmit())
+    behave like authorisedActionWithEnrolmentCheckRoute(routes.CheckYourAnswersController.onSubmit())
 
     "redirect to the registration submitted page after submitting the registration successfully" in {
       stubAuthorisedWithNoGroupEnrolment()

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/ConfirmContactAddressISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/ConfirmContactAddressISpec.scala
@@ -11,7 +11,7 @@ import uk.gov.hmrc.economiccrimelevyregistration.models._
 class ConfirmContactAddressISpec extends ISpecBase with AuthorisedBehaviour {
 
   s"GET ${routes.ConfirmContactAddressController.onPageLoad().url}" should {
-    behave like authorisedActionRoute(routes.ConfirmContactAddressController.onPageLoad())
+    behave like authorisedActionWithEnrolmentCheckRoute(routes.ConfirmContactAddressController.onPageLoad())
 
     "respond with 200 status and the confirm contact address HTML view" in {
       stubAuthorisedWithNoGroupEnrolment()
@@ -38,7 +38,7 @@ class ConfirmContactAddressISpec extends ISpecBase with AuthorisedBehaviour {
   }
 
   s"POST ${routes.ConfirmContactAddressController.onSubmit().url}"  should {
-    behave like authorisedActionRoute(routes.ConfirmContactAddressController.onSubmit())
+    behave like authorisedActionWithEnrolmentCheckRoute(routes.ConfirmContactAddressController.onSubmit())
 
     "save the selected answer then redirect to check your answers page when the Yes option is selected" in {
       stubAuthorisedWithNoGroupEnrolment()

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/EntityTypeISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/EntityTypeISpec.scala
@@ -12,7 +12,7 @@ import uk.gov.hmrc.economiccrimelevyregistration.models._
 class EntityTypeISpec extends ISpecBase with AuthorisedBehaviour {
 
   s"GET ${routes.EntityTypeController.onPageLoad().url}" should {
-    behave like authorisedActionRoute(routes.EntityTypeController.onPageLoad())
+    behave like authorisedActionWithEnrolmentCheckRoute(routes.EntityTypeController.onPageLoad())
 
     "respond with 200 status and the select entity type HTML view" in {
       stubAuthorisedWithNoGroupEnrolment()
@@ -30,7 +30,7 @@ class EntityTypeISpec extends ISpecBase with AuthorisedBehaviour {
   }
 
   s"POST ${routes.EntityTypeController.onSubmit().url}"  should {
-    behave like authorisedActionRoute(routes.EntityTypeController.onSubmit())
+    behave like authorisedActionWithEnrolmentCheckRoute(routes.EntityTypeController.onSubmit())
 
     "save the selected entity type then redirect to the GRS UK Limited Company journey when the UK Limited Company option is selected" in {
       stubAuthorisedWithNoGroupEnrolment()

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/FirstContactEmailISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/FirstContactEmailISpec.scala
@@ -13,7 +13,7 @@ class FirstContactEmailISpec extends ISpecBase with AuthorisedBehaviour {
   val emailMaxLength: Int = 160
 
   s"GET ${contacts.routes.FirstContactEmailController.onPageLoad().url}" should {
-    behave like authorisedActionRoute(contacts.routes.FirstContactEmailController.onPageLoad())
+    behave like authorisedActionWithEnrolmentCheckRoute(contacts.routes.FirstContactEmailController.onPageLoad())
 
     "respond with 200 status and the first contact email HTML view" in {
       stubAuthorisedWithNoGroupEnrolment()
@@ -38,7 +38,7 @@ class FirstContactEmailISpec extends ISpecBase with AuthorisedBehaviour {
   }
 
   s"POST ${contacts.routes.FirstContactEmailController.onSubmit().url}"  should {
-    behave like authorisedActionRoute(contacts.routes.FirstContactEmailController.onSubmit())
+    behave like authorisedActionWithEnrolmentCheckRoute(contacts.routes.FirstContactEmailController.onSubmit())
 
     "save the provided email address then redirect to the first contact telephone number page" in {
       stubAuthorisedWithNoGroupEnrolment()

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/FirstContactNameISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/FirstContactNameISpec.scala
@@ -13,7 +13,7 @@ class FirstContactNameISpec extends ISpecBase with AuthorisedBehaviour {
   val nameMaxLength: Int = 160
 
   s"GET ${contacts.routes.FirstContactNameController.onPageLoad().url}" should {
-    behave like authorisedActionRoute(contacts.routes.FirstContactNameController.onPageLoad())
+    behave like authorisedActionWithEnrolmentCheckRoute(contacts.routes.FirstContactNameController.onPageLoad())
 
     "respond with 200 status and the first contact name HTML view" in {
       stubAuthorisedWithNoGroupEnrolment()
@@ -31,7 +31,7 @@ class FirstContactNameISpec extends ISpecBase with AuthorisedBehaviour {
   }
 
   s"POST ${contacts.routes.FirstContactNameController.onSubmit().url}"  should {
-    behave like authorisedActionRoute(contacts.routes.FirstContactNameController.onSubmit())
+    behave like authorisedActionWithEnrolmentCheckRoute(contacts.routes.FirstContactNameController.onSubmit())
 
     "save the provided name then redirect to the first contact role page" in {
       stubAuthorisedWithNoGroupEnrolment()

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/FirstContactNumberISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/FirstContactNumberISpec.scala
@@ -13,7 +13,7 @@ class FirstContactNumberISpec extends ISpecBase with AuthorisedBehaviour {
   val numberMaxLength: Int = 24
 
   s"GET ${contacts.routes.FirstContactNumberController.onPageLoad().url}" should {
-    behave like authorisedActionRoute(contacts.routes.FirstContactNumberController.onPageLoad())
+    behave like authorisedActionWithEnrolmentCheckRoute(contacts.routes.FirstContactNumberController.onPageLoad())
 
     "respond with 200 status and the first contact number HTML view" in {
       stubAuthorisedWithNoGroupEnrolment()
@@ -38,7 +38,7 @@ class FirstContactNumberISpec extends ISpecBase with AuthorisedBehaviour {
   }
 
   s"POST ${contacts.routes.FirstContactNumberController.onSubmit().url}"  should {
-    behave like authorisedActionRoute(contacts.routes.FirstContactNumberController.onSubmit())
+    behave like authorisedActionWithEnrolmentCheckRoute(contacts.routes.FirstContactNumberController.onSubmit())
 
     "save the provided telephone number then redirect to the add another contact page" in {
       stubAuthorisedWithNoGroupEnrolment()

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/FirstContactRoleISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/FirstContactRoleISpec.scala
@@ -13,7 +13,7 @@ class FirstContactRoleISpec extends ISpecBase with AuthorisedBehaviour {
   val roleMaxLength: Int = 60
 
   s"GET ${contacts.routes.FirstContactRoleController.onPageLoad().url}" should {
-    behave like authorisedActionRoute(contacts.routes.FirstContactRoleController.onPageLoad())
+    behave like authorisedActionWithEnrolmentCheckRoute(contacts.routes.FirstContactRoleController.onPageLoad())
 
     "respond with 200 status and the first contact role HTML view" in {
       stubAuthorisedWithNoGroupEnrolment()
@@ -38,7 +38,7 @@ class FirstContactRoleISpec extends ISpecBase with AuthorisedBehaviour {
   }
 
   s"POST ${contacts.routes.FirstContactRoleController.onSubmit().url}"  should {
-    behave like authorisedActionRoute(contacts.routes.FirstContactRoleController.onSubmit())
+    behave like authorisedActionWithEnrolmentCheckRoute(contacts.routes.FirstContactRoleController.onSubmit())
 
     "save the provided role then redirect to the first contact email page" in {
       stubAuthorisedWithNoGroupEnrolment()

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/GrsContinueISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/GrsContinueISpec.scala
@@ -17,7 +17,7 @@ class GrsContinueISpec extends ISpecBase with AuthorisedBehaviour {
   val businessPartnerId: String = "test-business-partner-id"
 
   s"GET ${routes.GrsContinueController.continue(journeyId).url}" should {
-    behave like authorisedActionRoute(routes.GrsContinueController.continue(journeyId))
+    behave like authorisedActionWithEnrolmentCheckRoute(routes.GrsContinueController.continue(journeyId))
 
     "retrieve the incorporated entity GRS journey data, update the registration with the GRS journey data and handle the GRS/BV response to continue the registration journey" in {
       stubAuthorisedWithNoGroupEnrolment()

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/IsUkAddressISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/IsUkAddressISpec.scala
@@ -12,7 +12,7 @@ import uk.gov.hmrc.economiccrimelevyregistration.models.addresslookup._
 class IsUkAddressISpec extends ISpecBase with AuthorisedBehaviour {
 
   s"GET ${routes.IsUkAddressController.onPageLoad().url}" should {
-    behave like authorisedActionRoute(routes.IsUkAddressController.onPageLoad())
+    behave like authorisedActionWithEnrolmentCheckRoute(routes.IsUkAddressController.onPageLoad())
 
     "respond with 200 status and the is UK address HTML view" in {
       stubAuthorisedWithNoGroupEnrolment()
@@ -30,7 +30,7 @@ class IsUkAddressISpec extends ISpecBase with AuthorisedBehaviour {
   }
 
   s"POST ${routes.IsUkAddressController.onSubmit().url}"  should {
-    behave like authorisedActionRoute(routes.IsUkAddressController.onSubmit())
+    behave like authorisedActionWithEnrolmentCheckRoute(routes.IsUkAddressController.onSubmit())
 
     "save the selected address option then redirect to the address lookup frontend journey" in {
       stubAuthorisedWithNoGroupEnrolment()

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/NotLiableISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/NotLiableISpec.scala
@@ -27,7 +27,7 @@ import uk.gov.hmrc.economiccrimelevyregistration.models.Registration
 class NotLiableISpec extends ISpecBase with AuthorisedBehaviour {
 
   s"GET ${routes.NotLiableController.onPageLoad().url}" should {
-    behave like authorisedActionRoute(routes.NotLiableController.onPageLoad())
+    behave like authorisedActionWithEnrolmentCheckRoute(routes.NotLiableController.onPageLoad())
 
     "respond with 200 status and the start HTML view" in {
       stubAuthorisedWithNoGroupEnrolment()

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/RegisterWithOtherAmlSupervisorISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/RegisterWithOtherAmlSupervisorISpec.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.economiccrimelevyregistration.models.{AmlSupervisor, Registra
 class RegisterWithOtherAmlSupervisorISpec extends ISpecBase with AuthorisedBehaviour {
 
   s"GET ${routes.RegisterWithOtherAmlSupervisorController.onPageLoad().url}" should {
-    behave like authorisedActionRoute(routes.RegisterWithOtherAmlSupervisorController.onPageLoad())
+    behave like authorisedActionWithEnrolmentCheckRoute(routes.RegisterWithOtherAmlSupervisorController.onPageLoad())
 
     "respond with 200 status and the financial conduct authority HTML view" in {
       stubAuthorisedWithNoGroupEnrolment()

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/RegistrationSubmittedISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/RegistrationSubmittedISpec.scala
@@ -26,7 +26,7 @@ class RegistrationSubmittedISpec extends ISpecBase {
 
   s"GET ${routes.RegistrationSubmittedController.onPageLoad().url}" should {
     "respond with 200 status and the registration submitted HTML view" in {
-      stubAuthorisedWithNoGroupEnrolment()
+      stubAuthorisedWithEclEnrolment()
 
       val eclReference = random[String]
 

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/RegistrationSubmittedISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/RegistrationSubmittedISpec.scala
@@ -19,12 +19,15 @@ package uk.gov.hmrc.economiccrimelevyregistration
 import com.danielasfregola.randomdatagenerator.RandomDataGenerator.random
 import play.api.test.FakeRequest
 import uk.gov.hmrc.economiccrimelevyregistration.base.ISpecBase
+import uk.gov.hmrc.economiccrimelevyregistration.behaviours.AuthorisedBehaviour
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.routes
 import uk.gov.hmrc.economiccrimelevyregistration.models.SessionKeys
 
-class RegistrationSubmittedISpec extends ISpecBase {
+class RegistrationSubmittedISpec extends ISpecBase with AuthorisedBehaviour {
 
   s"GET ${routes.RegistrationSubmittedController.onPageLoad().url}" should {
+    behave like authorisedActionWithoutEnrolmentCheckRoute(routes.RegistrationSubmittedController.onPageLoad())
+
     "respond with 200 status and the registration submitted HTML view" in {
       stubAuthorisedWithEclEnrolment()
 

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/RelevantAp12MonthsISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/RelevantAp12MonthsISpec.scala
@@ -11,7 +11,7 @@ import uk.gov.hmrc.economiccrimelevyregistration.models._
 class RelevantAp12MonthsISpec extends ISpecBase with AuthorisedBehaviour {
 
   s"GET ${routes.RelevantAp12MonthsController.onPageLoad().url}" should {
-    behave like authorisedActionRoute(routes.RelevantAp12MonthsController.onPageLoad())
+    behave like authorisedActionWithEnrolmentCheckRoute(routes.RelevantAp12MonthsController.onPageLoad())
 
     "respond with 200 status and the relevant AP 12 months view" in {
       stubAuthorisedWithNoGroupEnrolment()
@@ -29,7 +29,7 @@ class RelevantAp12MonthsISpec extends ISpecBase with AuthorisedBehaviour {
   }
 
   s"POST ${routes.RelevantAp12MonthsController.onSubmit().url}"  should {
-    behave like authorisedActionRoute(routes.RelevantAp12MonthsController.onSubmit())
+    behave like authorisedActionWithEnrolmentCheckRoute(routes.RelevantAp12MonthsController.onSubmit())
 
     "save the selected option then redirect to the UK revenue page when the Yes option is selected" in {
       stubAuthorisedWithNoGroupEnrolment()

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/RelevantApLengthISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/RelevantApLengthISpec.scala
@@ -15,7 +15,7 @@ class RelevantApLengthISpec extends ISpecBase with AuthorisedBehaviour {
   val maxDays = 999
 
   s"GET ${routes.RelevantApLengthController.onPageLoad().url}" should {
-    behave like authorisedActionRoute(routes.RelevantApLengthController.onPageLoad())
+    behave like authorisedActionWithEnrolmentCheckRoute(routes.RelevantApLengthController.onPageLoad())
 
     "respond with 200 status and the relevant AP length view" in {
       stubAuthorisedWithNoGroupEnrolment()
@@ -33,7 +33,7 @@ class RelevantApLengthISpec extends ISpecBase with AuthorisedBehaviour {
   }
 
   s"POST ${routes.RelevantApLengthController.onSubmit().url}"  should {
-    behave like authorisedActionRoute(routes.RelevantApLengthController.onSubmit())
+    behave like authorisedActionWithEnrolmentCheckRoute(routes.RelevantApLengthController.onSubmit())
 
     "save the relevant AP length then redirect to the UK revenue page" in {
       stubAuthorisedWithNoGroupEnrolment()

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/SecondContactEmailISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/SecondContactEmailISpec.scala
@@ -13,7 +13,7 @@ class SecondContactEmailISpec extends ISpecBase with AuthorisedBehaviour {
   val emailMaxLength: Int = 160
 
   s"GET ${contacts.routes.SecondContactEmailController.onPageLoad().url}" should {
-    behave like authorisedActionRoute(contacts.routes.SecondContactEmailController.onPageLoad())
+    behave like authorisedActionWithEnrolmentCheckRoute(contacts.routes.SecondContactEmailController.onPageLoad())
 
     "respond with 200 status and the second contact email HTML view" in {
       stubAuthorisedWithNoGroupEnrolment()
@@ -38,7 +38,7 @@ class SecondContactEmailISpec extends ISpecBase with AuthorisedBehaviour {
   }
 
   s"POST ${contacts.routes.SecondContactEmailController.onSubmit().url}"  should {
-    behave like authorisedActionRoute(contacts.routes.SecondContactEmailController.onSubmit())
+    behave like authorisedActionWithEnrolmentCheckRoute(contacts.routes.SecondContactEmailController.onSubmit())
 
     "save the provided email address then redirect to the second contact telephone number page" in {
       stubAuthorisedWithNoGroupEnrolment()

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/SecondContactNameISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/SecondContactNameISpec.scala
@@ -13,7 +13,7 @@ class SecondContactNameISpec extends ISpecBase with AuthorisedBehaviour {
   val nameMaxLength: Int = 160
 
   s"GET ${contacts.routes.SecondContactNameController.onPageLoad().url}" should {
-    behave like authorisedActionRoute(contacts.routes.SecondContactNameController.onPageLoad())
+    behave like authorisedActionWithEnrolmentCheckRoute(contacts.routes.SecondContactNameController.onPageLoad())
 
     "respond with 200 status and the second contact name HTML view" in {
       stubAuthorisedWithNoGroupEnrolment()
@@ -31,7 +31,7 @@ class SecondContactNameISpec extends ISpecBase with AuthorisedBehaviour {
   }
 
   s"POST ${contacts.routes.SecondContactNameController.onSubmit().url}"  should {
-    behave like authorisedActionRoute(contacts.routes.SecondContactNameController.onSubmit())
+    behave like authorisedActionWithEnrolmentCheckRoute(contacts.routes.SecondContactNameController.onSubmit())
 
     "save the provided name then redirect to the second contact role page" in {
       stubAuthorisedWithNoGroupEnrolment()

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/SecondContactNumberISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/SecondContactNumberISpec.scala
@@ -13,7 +13,7 @@ class SecondContactNumberISpec extends ISpecBase with AuthorisedBehaviour {
   val numberMaxLength: Int = 24
 
   s"GET ${contacts.routes.SecondContactNumberController.onPageLoad().url}" should {
-    behave like authorisedActionRoute(contacts.routes.SecondContactNumberController.onPageLoad())
+    behave like authorisedActionWithEnrolmentCheckRoute(contacts.routes.SecondContactNumberController.onPageLoad())
 
     "respond with 200 status and the second contact number HTML view" in {
       stubAuthorisedWithNoGroupEnrolment()
@@ -38,7 +38,7 @@ class SecondContactNumberISpec extends ISpecBase with AuthorisedBehaviour {
   }
 
   s"POST ${contacts.routes.SecondContactNumberController.onSubmit().url}"  should {
-    behave like authorisedActionRoute(contacts.routes.SecondContactNumberController.onSubmit())
+    behave like authorisedActionWithEnrolmentCheckRoute(contacts.routes.SecondContactNumberController.onSubmit())
 
     "save the provided telephone number then redirect to the add another contact page" in {
       stubAuthorisedWithNoGroupEnrolment()

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/SecondContactRoleISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/SecondContactRoleISpec.scala
@@ -13,7 +13,7 @@ class SecondContactRoleISpec extends ISpecBase with AuthorisedBehaviour {
   val roleMaxLength: Int = 60
 
   s"GET ${contacts.routes.SecondContactRoleController.onPageLoad().url}" should {
-    behave like authorisedActionRoute(contacts.routes.SecondContactRoleController.onPageLoad())
+    behave like authorisedActionWithEnrolmentCheckRoute(contacts.routes.SecondContactRoleController.onPageLoad())
 
     "respond with 200 status and the second contact role HTML view" in {
       stubAuthorisedWithNoGroupEnrolment()
@@ -38,7 +38,7 @@ class SecondContactRoleISpec extends ISpecBase with AuthorisedBehaviour {
   }
 
   s"POST ${contacts.routes.SecondContactRoleController.onSubmit().url}"  should {
-    behave like authorisedActionRoute(contacts.routes.SecondContactRoleController.onSubmit())
+    behave like authorisedActionWithEnrolmentCheckRoute(contacts.routes.SecondContactRoleController.onSubmit())
 
     "save the provided role then redirect to the second contact email page" in {
       stubAuthorisedWithNoGroupEnrolment()

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/UkRevenueISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/UkRevenueISpec.scala
@@ -18,7 +18,7 @@ class UkRevenueISpec extends ISpecBase with AuthorisedBehaviour {
   val revenueGen: Gen[Long] = Gen.chooseNum[Long](minRevenue, maxRevenue)
 
   s"GET ${routes.UkRevenueController.onPageLoad().url}" should {
-    behave like authorisedActionRoute(routes.UkRevenueController.onPageLoad())
+    behave like authorisedActionWithEnrolmentCheckRoute(routes.UkRevenueController.onPageLoad())
 
     "respond with 200 status and the UK revenue view" in {
       stubAuthorisedWithNoGroupEnrolment()
@@ -36,7 +36,7 @@ class UkRevenueISpec extends ISpecBase with AuthorisedBehaviour {
   }
 
   s"POST ${routes.UkRevenueController.onSubmit().url}"  should {
-    behave like authorisedActionRoute(routes.UkRevenueController.onSubmit())
+    behave like authorisedActionWithEnrolmentCheckRoute(routes.UkRevenueController.onSubmit())
 
     "save the UK revenue then redirect to the entity type page if the amount due is more than 0" in {
       stubAuthorisedWithNoGroupEnrolment()

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/base/ISpecBase.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/base/ISpecBase.scala
@@ -39,6 +39,7 @@ abstract class ISpecBase
     with HeaderNames
     with MimeTypes
     with ResultExtractors
+    with OptionValues
     with WireMockHelper
     with WireMockStubs
     with Generators {
@@ -72,7 +73,7 @@ abstract class ISpecBase
       .in(Mode.Test)
       .build()
 
-  val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+  val appConfig: AppConfig              = app.injector.instanceOf[AppConfig]
   implicit val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
 
   /*

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/behaviours/AuthorisedBehaviour.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/behaviours/AuthorisedBehaviour.scala
@@ -10,7 +10,16 @@ trait AuthorisedBehaviour {
   self: ISpecBase =>
 
   def authorisedActionWithEnrolmentCheckRoute(call: Call): Unit =
-    "authorisedAction" should {
+    "authorisedActionWithEnrolmentCheckRoute" should {
+      "redirect to sign in when there is no auth session" in {
+        stubUnauthorised()
+
+        val result: Future[Result] = callRoute(FakeRequest(call))
+
+        status(result)               shouldBe SEE_OTHER
+        redirectLocation(result).value should startWith(appConfig.signInUrl)
+      }
+
       "go to already registered page if the user has the ECL enrolment" in {
         stubAuthorisedWithEclEnrolment()
 
@@ -28,6 +37,36 @@ trait AuthorisedBehaviour {
 
         status(result)          shouldBe OK
         contentAsString(result) shouldBe "Group already has the enrolment - assign the enrolment to the user"
+      }
+
+      "go to the agent not supported page if the user has an agent affinity group" in {
+        stubAuthorisedWithAgentAffinityGroup()
+
+        val result: Future[Result] = callRoute(FakeRequest(call))
+
+        status(result)          shouldBe OK
+        contentAsString(result) shouldBe "Agent account not supported - must be an organisation or individual"
+      }
+
+      "go to the assistant not supported page if the user has an assistant credential role" in {
+        stubAuthorisedWithAssistantCredentialRole()
+
+        val result: Future[Result] = callRoute(FakeRequest(call))
+
+        status(result)          shouldBe OK
+        contentAsString(result) shouldBe "User is not an Admin - request an admin to perform registration"
+      }
+    }
+
+  def authorisedActionWithoutEnrolmentCheckRoute(call: Call): Unit =
+    "authorisedActionWithoutEnrolmentCheckRoute" should {
+      "redirect to sign in when there is no auth session" in {
+        stubUnauthorised()
+
+        val result: Future[Result] = callRoute(FakeRequest(call))
+
+        status(result)               shouldBe SEE_OTHER
+        redirectLocation(result).value should startWith(appConfig.signInUrl)
       }
 
       "go to the agent not supported page if the user has an agent affinity group" in {

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/behaviours/AuthorisedBehaviour.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/behaviours/AuthorisedBehaviour.scala
@@ -9,7 +9,7 @@ import scala.concurrent.Future
 trait AuthorisedBehaviour {
   self: ISpecBase =>
 
-  def authorisedActionRoute(call: Call): Unit =
+  def authorisedActionWithEnrolmentCheckRoute(call: Call): Unit =
     "authorisedAction" should {
       "go to already registered page if the user has the ECL enrolment" in {
         stubAuthorisedWithEclEnrolment()

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/base/SpecBase.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/base/SpecBase.scala
@@ -28,7 +28,7 @@ import play.api.test.Helpers.{stubBodyParser, stubControllerComponents}
 import play.api.test.{DefaultAwaitTimeout, FakeRequest, FutureAwaits}
 import uk.gov.hmrc.economiccrimelevyregistration.EclTestData
 import uk.gov.hmrc.economiccrimelevyregistration.config.AppConfig
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{FakeAuthorisedAction, FakeDataRetrievalAction}
+import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{FakeAuthorisedActionWithEnrolmentCheck, FakeAuthorisedActionWithoutEnrolmentCheck, FakeDataRetrievalAction}
 import uk.gov.hmrc.economiccrimelevyregistration.generators.Generators
 import uk.gov.hmrc.economiccrimelevyregistration.models.Registration
 import uk.gov.hmrc.http.HeaderCarrier
@@ -59,7 +59,8 @@ trait SpecBase
   val appConfig: AppConfig                             = app.injector.instanceOf[AppConfig]
   val messages: Messages                               = messagesApi.preferred(fakeRequest)
   val bodyParsers: PlayBodyParsers                     = app.injector.instanceOf[PlayBodyParsers]
-  val fakeAuthorisedAction                             = new FakeAuthorisedAction(bodyParsers)
+  val fakeAuthorisedActionWithEnrolmentCheck           = new FakeAuthorisedActionWithEnrolmentCheck(bodyParsers)
+  val fakeAuthorisedActionWithoutEnrolmentCheck        = new FakeAuthorisedActionWithoutEnrolmentCheck(bodyParsers)
 
   def fakeDataRetrievalAction(data: Registration) = new FakeDataRetrievalAction(data)
 

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/AddressLookupContinueControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/AddressLookupContinueControllerSpec.scala
@@ -36,7 +36,7 @@ class AddressLookupContinueControllerSpec extends SpecBase {
   class TestContext(registrationData: Registration) {
     val controller = new AddressLookupContinueController(
       mcc,
-      fakeAuthorisedAction,
+      fakeAuthorisedActionWithEnrolmentCheck,
       fakeDataRetrievalAction(registrationData),
       mockAddressLookupFrontendConnector,
       mockEclRegistrationConnector

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/AmlRegulatedActivityControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/AmlRegulatedActivityControllerSpec.scala
@@ -47,7 +47,7 @@ class AmlRegulatedActivityControllerSpec extends SpecBase {
   class TestContext(registrationData: Registration) {
     val controller = new AmlRegulatedActivityController(
       mcc,
-      fakeAuthorisedAction,
+      fakeAuthorisedActionWithEnrolmentCheck,
       fakeDataRetrievalAction(registrationData),
       mockEclRegistrationConnector,
       formProvider,

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/AmlSupervisorControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/AmlSupervisorControllerSpec.scala
@@ -51,7 +51,7 @@ class AmlSupervisorControllerSpec extends SpecBase {
   class TestContext(registrationData: Registration) {
     val controller = new AmlSupervisorController(
       mcc,
-      fakeAuthorisedAction,
+      fakeAuthorisedActionWithEnrolmentCheck,
       fakeDataRetrievalAction(registrationData),
       mockEclRegistrationConnector,
       formProvider,

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/BusinessSectorControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/BusinessSectorControllerSpec.scala
@@ -47,7 +47,7 @@ class BusinessSectorControllerSpec extends SpecBase {
   class TestContext(registrationData: Registration) {
     val controller = new BusinessSectorController(
       mcc,
-      fakeAuthorisedAction,
+      fakeAuthorisedActionWithEnrolmentCheck,
       fakeDataRetrievalAction(registrationData),
       mockEclRegistrationConnector,
       formProvider,

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/CheckYourAnswersControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/CheckYourAnswersControllerSpec.scala
@@ -43,7 +43,7 @@ class CheckYourAnswersControllerSpec extends SpecBase {
   class TestContext(registrationData: Registration) {
     val controller = new CheckYourAnswersController(
       messagesApi,
-      fakeAuthorisedAction,
+      fakeAuthorisedActionWithEnrolmentCheck,
       fakeDataRetrievalAction(registrationData),
       mockEclRegistrationConnector,
       mcc,

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/ConfirmContactAddressControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/ConfirmContactAddressControllerSpec.scala
@@ -53,7 +53,7 @@ class ConfirmContactAddressControllerSpec extends SpecBase {
   class TestContext(registrationData: Registration) {
     val controller = new ConfirmContactAddressController(
       mcc,
-      fakeAuthorisedAction,
+      fakeAuthorisedActionWithEnrolmentCheck,
       fakeDataRetrievalAction(registrationData),
       mockEclRegistrationConnector,
       formProvider,

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/EntityTypeControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/EntityTypeControllerSpec.scala
@@ -53,7 +53,7 @@ class EntityTypeControllerSpec extends SpecBase {
   class TestContext(registrationData: Registration) {
     val controller = new EntityTypeController(
       mcc,
-      fakeAuthorisedAction,
+      fakeAuthorisedActionWithEnrolmentCheck,
       fakeDataRetrievalAction(registrationData),
       mockEclRegistrationConnector,
       formProvider,

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/GrsContinueControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/GrsContinueControllerSpec.scala
@@ -46,7 +46,7 @@ class GrsContinueControllerSpec extends SpecBase {
   class TestContext(registrationData: Registration) {
     val controller = new GrsContinueController(
       mcc,
-      fakeAuthorisedAction,
+      fakeAuthorisedActionWithEnrolmentCheck,
       fakeDataRetrievalAction(registrationData),
       mockIncorporatedEntityIdentificationFrontendConnector,
       mockSoleTraderIdentificationFrontendConnector,

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/IsUkAddressControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/IsUkAddressControllerSpec.scala
@@ -51,7 +51,7 @@ class IsUkAddressControllerSpec extends SpecBase {
   class TestContext(registrationData: Registration) {
     val controller = new IsUkAddressController(
       mcc,
-      fakeAuthorisedAction,
+      fakeAuthorisedActionWithEnrolmentCheck,
       fakeDataRetrievalAction(registrationData),
       mockEclRegistrationConnector,
       formProvider,

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/JourneyRecoveryControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/JourneyRecoveryControllerSpec.scala
@@ -32,7 +32,7 @@ class JourneyRecoveryControllerSpec extends SpecBase {
   class TestContext(registrationData: Registration) {
     val controller = new JourneyRecoveryController(
       mcc,
-      fakeAuthorisedAction,
+      fakeAuthorisedActionWithEnrolmentCheck,
       fakeDataRetrievalAction(registrationData),
       view
     )

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/NotLiableControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/NotLiableControllerSpec.scala
@@ -32,7 +32,7 @@ class NotLiableControllerSpec extends SpecBase {
   class TestContext(registrationData: Registration) {
     val controller = new NotLiableController(
       mcc,
-      fakeAuthorisedAction,
+      fakeAuthorisedActionWithEnrolmentCheck,
       view,
       fakeDataRetrievalAction(registrationData)
     )

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegisterWithOtherAmlSupervisorControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegisterWithOtherAmlSupervisorControllerSpec.scala
@@ -35,7 +35,7 @@ class RegisterWithOtherAmlSupervisorControllerSpec extends SpecBase {
   class TestContext(registrationData: Registration) {
     val controller = new RegisterWithOtherAmlSupervisorController(
       mcc,
-      fakeAuthorisedAction,
+      fakeAuthorisedActionWithEnrolmentCheck,
       fakeDataRetrievalAction(registrationData),
       gcView,
       fcaView

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationSubmittedControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationSubmittedControllerSpec.scala
@@ -30,7 +30,7 @@ class RegistrationSubmittedControllerSpec extends SpecBase {
 
   val controller = new RegistrationSubmittedController(
     mcc,
-    fakeAuthorisedAction,
+    fakeAuthorisedActionWithoutEnrolmentCheck,
     view
   )
 

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/RelevantAp12MonthsControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/RelevantAp12MonthsControllerSpec.scala
@@ -47,7 +47,7 @@ class RelevantAp12MonthsControllerSpec extends SpecBase {
   class TestContext(registrationData: Registration) {
     val controller = new RelevantAp12MonthsController(
       mcc,
-      fakeAuthorisedAction,
+      fakeAuthorisedActionWithEnrolmentCheck,
       fakeDataRetrievalAction(registrationData),
       mockEclRegistrationConnector,
       formProvider,

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/RelevantApLengthControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/RelevantApLengthControllerSpec.scala
@@ -53,7 +53,7 @@ class RelevantApLengthControllerSpec extends SpecBase {
   class TestContext(registrationData: Registration) {
     val controller = new RelevantApLengthController(
       mcc,
-      fakeAuthorisedAction,
+      fakeAuthorisedActionWithEnrolmentCheck,
       fakeDataRetrievalAction(registrationData),
       mockEclRegistrationConnector,
       formProvider,

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/SignOutControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/SignOutControllerSpec.scala
@@ -29,7 +29,7 @@ class SignOutControllerSpec extends SpecBase {
   val controller = new SignOutController(
     mcc,
     appConfig,
-    fakeAuthorisedAction,
+    fakeAuthorisedActionWithoutEnrolmentCheck,
     view
   )
 

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/UkRevenueControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/UkRevenueControllerSpec.scala
@@ -53,7 +53,7 @@ class UkRevenueControllerSpec extends SpecBase {
   class TestContext(registrationData: Registration) {
     val controller = new UkRevenueController(
       mcc,
-      fakeAuthorisedAction,
+      fakeAuthorisedActionWithEnrolmentCheck,
       fakeDataRetrievalAction(registrationData),
       mockEclRegistrationConnector,
       formProvider,

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/actions/AuthorisedActionWithEnrolmentCheckSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/actions/AuthorisedActionWithEnrolmentCheckSpec.scala
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.economiccrimelevyregistration.controllers.actions
+
+import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.any
+import play.api.mvc.{BodyParsers, Request, Result}
+import play.api.test.Helpers._
+import uk.gov.hmrc.auth.core.AffinityGroup.{Agent, Organisation}
+import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
+import uk.gov.hmrc.auth.core.retrieve.{Retrieval, ~}
+import uk.gov.hmrc.auth.core.syntax.retrieved.authSyntaxForRetrieved
+import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
+import uk.gov.hmrc.economiccrimelevyregistration.models.eacd.EclEnrolment
+import uk.gov.hmrc.economiccrimelevyregistration.services.EnrolmentStoreProxyService
+import uk.gov.hmrc.economiccrimelevyregistration.{EnrolmentsWithEcl, EnrolmentsWithoutEcl}
+
+import scala.concurrent.Future
+
+class AuthorisedActionWithEnrolmentCheckSpec extends SpecBase {
+
+  val defaultBodyParser: BodyParsers.Default                     = app.injector.instanceOf[BodyParsers.Default]
+  val mockAuthConnector: AuthConnector                           = mock[AuthConnector]
+  val mockEnrolmentStoreProxyService: EnrolmentStoreProxyService = mock[EnrolmentStoreProxyService]
+
+  val authorisedAction =
+    new AuthorisedActionWithEnrolmentCheckImpl(
+      mockAuthConnector,
+      mockEnrolmentStoreProxyService,
+      appConfig,
+      defaultBodyParser
+    )
+
+  val testAction: Request[_] => Future[Result] = { _ =>
+    Future(Ok("Test"))
+  }
+
+  val eclEnrolmentKey: String = EclEnrolment.ServiceName
+
+  val expectedRetrievals
+    : Retrieval[Option[String] ~ Enrolments ~ Option[String] ~ Option[AffinityGroup] ~ Option[CredentialRole]] =
+    Retrievals.internalId and Retrievals.allEnrolments and Retrievals.groupIdentifier and Retrievals.affinityGroup and Retrievals.credentialRole
+
+  "invokeBlock" should {
+    "execute the block and return the result if authorised" in forAll {
+      (internalId: String, enrolmentsWithoutEcl: EnrolmentsWithoutEcl, groupId: String) =>
+        when(mockAuthConnector.authorise(any(), ArgumentMatchers.eq(expectedRetrievals))(any(), any()))
+          .thenReturn(
+            Future(
+              Some(internalId) and enrolmentsWithoutEcl.enrolments and Some(groupId) and Some(Organisation) and Some(
+                User
+              )
+            )
+          )
+
+        when(mockEnrolmentStoreProxyService.groupHasEnrolment(ArgumentMatchers.eq(groupId))(any()))
+          .thenReturn(Future.successful(false))
+
+        val result: Future[Result] = authorisedAction.invokeBlock(fakeRequest, testAction)
+
+        status(result)          shouldBe OK
+        contentAsString(result) shouldBe "Test"
+    }
+
+    "redirect the user to sign in when there is no active session" in {
+      List(BearerTokenExpired(), MissingBearerToken(), InvalidBearerToken(), SessionRecordNotFound()).foreach {
+        exception =>
+          when(mockAuthConnector.authorise[Unit](any(), any())(any(), any())).thenReturn(Future.failed(exception))
+
+          val result: Future[Result] = authorisedAction.invokeBlock(fakeRequest, testAction)
+
+          status(result)               shouldBe SEE_OTHER
+          redirectLocation(result).value should startWith(appConfig.signInUrl)
+      }
+    }
+
+    "redirect the user to the already registered page if they have the ECL enrolment" in forAll {
+      (internalId: String, enrolmentsWithEcl: EnrolmentsWithEcl, groupId: String) =>
+        when(
+          mockAuthConnector
+            .authorise(any(), ArgumentMatchers.eq(expectedRetrievals))(any(), any())
+        )
+          .thenReturn(
+            Future(
+              Some(internalId) and enrolmentsWithEcl.enrolments and Some(groupId) and Some(Organisation) and Some(User)
+            )
+          )
+
+        val result: Future[Result] = authorisedAction.invokeBlock(fakeRequest, testAction)
+
+        status(result)          shouldBe OK
+        contentAsString(result) shouldBe "Already registered - user already has enrolment"
+    }
+
+    "redirect the user to the group already registered page if they do not have the ECL enrolment but the group does" in forAll {
+      (
+        internalId: String,
+        enrolmentsWithoutEcl: EnrolmentsWithoutEcl,
+        groupId: String
+      ) =>
+        when(
+          mockAuthConnector
+            .authorise(any(), ArgumentMatchers.eq(expectedRetrievals))(any(), any())
+        )
+          .thenReturn(
+            Future(
+              Some(internalId) and enrolmentsWithoutEcl.enrolments and Some(groupId) and Some(Organisation) and Some(
+                User
+              )
+            )
+          )
+
+        when(mockEnrolmentStoreProxyService.groupHasEnrolment(ArgumentMatchers.eq(groupId))(any()))
+          .thenReturn(Future.successful(true))
+
+        val result: Future[Result] = authorisedAction.invokeBlock(fakeRequest, testAction)
+
+        status(result)          shouldBe OK
+        contentAsString(result) shouldBe "Group already has the enrolment - assign the enrolment to the user"
+    }
+
+    "redirect the user to the agent not supported page if they have an agent affinity group" in forAll {
+      (internalId: String, enrolmentsWithoutEcl: EnrolmentsWithoutEcl, groupId: String) =>
+        when(
+          mockAuthConnector
+            .authorise(any(), ArgumentMatchers.eq(expectedRetrievals))(any(), any())
+        )
+          .thenReturn(
+            Future(
+              Some(internalId) and enrolmentsWithoutEcl.enrolments and Some(groupId) and Some(Agent) and Some(User)
+            )
+          )
+
+        when(mockEnrolmentStoreProxyService.groupHasEnrolment(ArgumentMatchers.eq(groupId))(any()))
+          .thenReturn(Future.successful(false))
+
+        val result: Future[Result] = authorisedAction.invokeBlock(fakeRequest, testAction)
+
+        status(result)          shouldBe OK
+        contentAsString(result) shouldBe "Agent account not supported - must be an organisation or individual"
+    }
+
+    "redirect the user to the assistant not supported page if they have an assistant credential role" in forAll {
+      (internalId: String, enrolmentsWithEcl: EnrolmentsWithEcl, groupId: String) =>
+        when(
+          mockAuthConnector
+            .authorise(any(), ArgumentMatchers.eq(expectedRetrievals))(any(), any())
+        )
+          .thenReturn(
+            Future(
+              Some(internalId) and enrolmentsWithEcl.enrolments and Some(groupId) and Some(Organisation) and Some(
+                Assistant
+              )
+            )
+          )
+
+        val result: Future[Result] = authorisedAction.invokeBlock(fakeRequest, testAction)
+
+        status(result)          shouldBe OK
+        contentAsString(result) shouldBe "User is not an Admin - request an admin to perform registration"
+    }
+
+    "throw an IllegalStateException if there is no internal id" in {
+      when(mockAuthConnector.authorise(any(), ArgumentMatchers.eq(expectedRetrievals))(any(), any()))
+        .thenReturn(Future(None and Enrolments(Set.empty) and Some("") and Some(Organisation) and Some(User)))
+
+      val result = intercept[IllegalStateException] {
+        await(authorisedAction.invokeBlock(fakeRequest, testAction))
+      }
+
+      result.getMessage shouldBe "Unable to retrieve internalId"
+    }
+
+    "throw an IllegalStateException if there is no group id" in {
+      when(mockAuthConnector.authorise(any(), ArgumentMatchers.eq(expectedRetrievals))(any(), any()))
+        .thenReturn(Future(Some("") and Enrolments(Set.empty) and None and Some(Organisation) and Some(User)))
+
+      val result = intercept[IllegalStateException] {
+        await(authorisedAction.invokeBlock(fakeRequest, testAction))
+      }
+
+      result.getMessage shouldBe "Unable to retrieve groupIdentifier"
+    }
+
+    "throw an IllegalStateException if there is no affinity group" in {
+      when(mockAuthConnector.authorise(any(), ArgumentMatchers.eq(expectedRetrievals))(any(), any()))
+        .thenReturn(Future(Some("") and Enrolments(Set.empty) and Some("") and None and Some(User)))
+
+      val result = intercept[IllegalStateException] {
+        await(authorisedAction.invokeBlock(fakeRequest, testAction))
+      }
+
+      result.getMessage shouldBe "Unable to retrieve affinityGroup"
+    }
+
+    "throw an IllegalStateException if there is no credential role" in {
+      when(mockAuthConnector.authorise(any(), ArgumentMatchers.eq(expectedRetrievals))(any(), any()))
+        .thenReturn(Future(Some("") and Enrolments(Set.empty) and Some("") and Some(Organisation) and None))
+
+      val result = intercept[IllegalStateException] {
+        await(authorisedAction.invokeBlock(fakeRequest, testAction))
+      }
+
+      result.getMessage shouldBe "Unable to retrieve credentialRole"
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/actions/AuthorisedActionWithoutEnrolmentCheckSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/actions/AuthorisedActionWithoutEnrolmentCheckSpec.scala
@@ -89,51 +89,6 @@ class AuthorisedActionWithoutEnrolmentCheckSpec extends SpecBase {
       }
     }
 
-    "redirect the user to the already registered page if they have the ECL enrolment" in forAll {
-      (internalId: String, enrolmentsWithEcl: EnrolmentsWithEcl, groupId: String) =>
-        when(
-          mockAuthConnector
-            .authorise(any(), ArgumentMatchers.eq(expectedRetrievals))(any(), any())
-        )
-          .thenReturn(
-            Future(
-              Some(internalId) and enrolmentsWithEcl.enrolments and Some(groupId) and Some(Organisation) and Some(User)
-            )
-          )
-
-        val result: Future[Result] = authorisedAction.invokeBlock(fakeRequest, testAction)
-
-        status(result)          shouldBe OK
-        contentAsString(result) shouldBe "Already registered - user already has enrolment"
-    }
-
-    "redirect the user to the group already registered page if they do not have the ECL enrolment but the group does" in forAll {
-      (
-        internalId: String,
-        enrolmentsWithoutEcl: EnrolmentsWithoutEcl,
-        groupId: String
-      ) =>
-        when(
-          mockAuthConnector
-            .authorise(any(), ArgumentMatchers.eq(expectedRetrievals))(any(), any())
-        )
-          .thenReturn(
-            Future(
-              Some(internalId) and enrolmentsWithoutEcl.enrolments and Some(groupId) and Some(Organisation) and Some(
-                User
-              )
-            )
-          )
-
-        when(mockEnrolmentStoreProxyService.groupHasEnrolment(ArgumentMatchers.eq(groupId))(any()))
-          .thenReturn(Future.successful(true))
-
-        val result: Future[Result] = authorisedAction.invokeBlock(fakeRequest, testAction)
-
-        status(result)          shouldBe OK
-        contentAsString(result) shouldBe "Group already has the enrolment - assign the enrolment to the user"
-    }
-
     "redirect the user to the agent not supported page if they have an agent affinity group" in forAll {
       (internalId: String, enrolmentsWithoutEcl: EnrolmentsWithoutEcl, groupId: String) =>
         when(

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/actions/AuthorisedActionWithoutEnrolmentCheckSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/actions/AuthorisedActionWithoutEnrolmentCheckSpec.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.auth.core.syntax.retrieved.authSyntaxForRetrieved
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.models.eacd.EclEnrolment
 import uk.gov.hmrc.economiccrimelevyregistration.services.EnrolmentStoreProxyService
-import uk.gov.hmrc.economiccrimelevyregistration.{EnrolmentsWithEcl, EnrolmentsWithoutEcl}
+import uk.gov.hmrc.economiccrimelevyregistration.EnrolmentsWithEcl
 
 import scala.concurrent.Future
 
@@ -58,11 +58,11 @@ class AuthorisedActionWithoutEnrolmentCheckSpec extends SpecBase {
 
   "invokeBlock" should {
     "execute the block and return the result if authorised" in forAll {
-      (internalId: String, enrolmentsWithoutEcl: EnrolmentsWithoutEcl, groupId: String) =>
+      (internalId: String, enrolmentsWithEcl: EnrolmentsWithEcl, groupId: String) =>
         when(mockAuthConnector.authorise(any(), ArgumentMatchers.eq(expectedRetrievals))(any(), any()))
           .thenReturn(
             Future(
-              Some(internalId) and enrolmentsWithoutEcl.enrolments and Some(groupId) and Some(Organisation) and Some(
+              Some(internalId) and enrolmentsWithEcl.enrolments and Some(groupId) and Some(Organisation) and Some(
                 User
               )
             )
@@ -90,14 +90,14 @@ class AuthorisedActionWithoutEnrolmentCheckSpec extends SpecBase {
     }
 
     "redirect the user to the agent not supported page if they have an agent affinity group" in forAll {
-      (internalId: String, enrolmentsWithoutEcl: EnrolmentsWithoutEcl, groupId: String) =>
+      (internalId: String, enrolmentsWithEcl: EnrolmentsWithEcl, groupId: String) =>
         when(
           mockAuthConnector
             .authorise(any(), ArgumentMatchers.eq(expectedRetrievals))(any(), any())
         )
           .thenReturn(
             Future(
-              Some(internalId) and enrolmentsWithoutEcl.enrolments and Some(groupId) and Some(Agent) and Some(User)
+              Some(internalId) and enrolmentsWithEcl.enrolments and Some(groupId) and Some(Agent) and Some(User)
             )
           )
 

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/actions/AuthorisedActionWithoutEnrolmentCheckSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/actions/AuthorisedActionWithoutEnrolmentCheckSpec.scala
@@ -32,14 +32,19 @@ import uk.gov.hmrc.economiccrimelevyregistration.{EnrolmentsWithEcl, EnrolmentsW
 
 import scala.concurrent.Future
 
-class AuthorisedActionSpec extends SpecBase {
+class AuthorisedActionWithoutEnrolmentCheckSpec extends SpecBase {
 
   val defaultBodyParser: BodyParsers.Default                     = app.injector.instanceOf[BodyParsers.Default]
   val mockAuthConnector: AuthConnector                           = mock[AuthConnector]
   val mockEnrolmentStoreProxyService: EnrolmentStoreProxyService = mock[EnrolmentStoreProxyService]
 
   val authorisedAction =
-    new BaseAuthorisedAction(mockAuthConnector, mockEnrolmentStoreProxyService, appConfig, defaultBodyParser)
+    new AuthorisedActionWithoutEnrolmentCheckImpl(
+      mockAuthConnector,
+      mockEnrolmentStoreProxyService,
+      appConfig,
+      defaultBodyParser
+    )
 
   val testAction: Request[_] => Future[Result] = { _ =>
     Future(Ok("Test"))

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/actions/FakeAuthorisedActionWithEnrolmentCheck.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/actions/FakeAuthorisedActionWithEnrolmentCheck.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.economiccrimelevyregistration.controllers.actions
+
+import play.api.mvc._
+import uk.gov.hmrc.economiccrimelevyregistration.models.requests.AuthorisedRequest
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class FakeAuthorisedActionWithEnrolmentCheck @Inject() (bodyParsers: PlayBodyParsers)
+    extends AuthorisedActionWithEnrolmentCheck {
+
+  override def parser: BodyParser[AnyContent] = bodyParsers.defaultBodyParser
+
+  override def invokeBlock[A](request: Request[A], block: AuthorisedRequest[A] => Future[Result]): Future[Result] =
+    block(AuthorisedRequest(request, "test-internal-id", "test-group-id"))
+
+  override protected def executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+
+}

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/actions/FakeAuthorisedActionWithoutEnrolmentCheck.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/actions/FakeAuthorisedActionWithoutEnrolmentCheck.scala
@@ -22,7 +22,8 @@ import uk.gov.hmrc.economiccrimelevyregistration.models.requests.AuthorisedReque
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
-class FakeAuthorisedAction @Inject() (bodyParsers: PlayBodyParsers) extends AuthorisedAction {
+class FakeAuthorisedActionWithoutEnrolmentCheck @Inject() (bodyParsers: PlayBodyParsers)
+    extends AuthorisedActionWithoutEnrolmentCheck {
 
   override def parser: BodyParser[AnyContent] = bodyParsers.defaultBodyParser
 

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/AddAnotherContactControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/AddAnotherContactControllerSpec.scala
@@ -47,7 +47,7 @@ class AddAnotherContactControllerSpec extends SpecBase {
   class TestContext(registrationData: Registration) {
     val controller = new AddAnotherContactController(
       mcc,
-      fakeAuthorisedAction,
+      fakeAuthorisedActionWithEnrolmentCheck,
       fakeDataRetrievalAction(registrationData),
       mockEclRegistrationConnector,
       formProvider,

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/FirstContactEmailControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/FirstContactEmailControllerSpec.scala
@@ -50,7 +50,7 @@ class FirstContactEmailControllerSpec extends SpecBase {
   class TestContext(registrationData: Registration) {
     val controller = new FirstContactEmailController(
       mcc,
-      fakeAuthorisedAction,
+      fakeAuthorisedActionWithEnrolmentCheck,
       fakeDataRetrievalAction(registrationData),
       mockEclRegistrationConnector,
       formProvider,

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/FirstContactNameControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/FirstContactNameControllerSpec.scala
@@ -50,7 +50,7 @@ class FirstContactNameControllerSpec extends SpecBase {
   class TestContext(registrationData: Registration) {
     val controller = new FirstContactNameController(
       mcc,
-      fakeAuthorisedAction,
+      fakeAuthorisedActionWithEnrolmentCheck,
       fakeDataRetrievalAction(registrationData),
       mockEclRegistrationConnector,
       formProvider,

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/FirstContactNumberControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/FirstContactNumberControllerSpec.scala
@@ -50,7 +50,7 @@ class FirstContactNumberControllerSpec extends SpecBase {
   class TestContext(registrationData: Registration) {
     val controller = new FirstContactNumberController(
       mcc,
-      fakeAuthorisedAction,
+      fakeAuthorisedActionWithEnrolmentCheck,
       fakeDataRetrievalAction(registrationData),
       mockEclRegistrationConnector,
       formProvider,

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/FirstContactRoleControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/FirstContactRoleControllerSpec.scala
@@ -50,7 +50,7 @@ class FirstContactRoleControllerSpec extends SpecBase {
   class TestContext(registrationData: Registration) {
     val controller = new FirstContactRoleController(
       mcc,
-      fakeAuthorisedAction,
+      fakeAuthorisedActionWithEnrolmentCheck,
       fakeDataRetrievalAction(registrationData),
       mockEclRegistrationConnector,
       formProvider,

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/SecondContactEmailControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/SecondContactEmailControllerSpec.scala
@@ -50,7 +50,7 @@ class SecondContactEmailControllerSpec extends SpecBase {
   class TestContext(registrationData: Registration) {
     val controller = new SecondContactEmailController(
       mcc,
-      fakeAuthorisedAction,
+      fakeAuthorisedActionWithEnrolmentCheck,
       fakeDataRetrievalAction(registrationData),
       mockEclRegistrationConnector,
       formProvider,

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/SecondContactNameControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/SecondContactNameControllerSpec.scala
@@ -50,7 +50,7 @@ class SecondContactNameControllerSpec extends SpecBase {
   class TestContext(registrationData: Registration) {
     val controller = new SecondContactNameController(
       mcc,
-      fakeAuthorisedAction,
+      fakeAuthorisedActionWithEnrolmentCheck,
       fakeDataRetrievalAction(registrationData),
       mockEclRegistrationConnector,
       formProvider,

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/SecondContactNumberControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/SecondContactNumberControllerSpec.scala
@@ -50,7 +50,7 @@ class SecondContactNumberControllerSpec extends SpecBase {
   class TestContext(registrationData: Registration) {
     val controller = new SecondContactNumberController(
       mcc,
-      fakeAuthorisedAction,
+      fakeAuthorisedActionWithEnrolmentCheck,
       fakeDataRetrievalAction(registrationData),
       mockEclRegistrationConnector,
       formProvider,

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/SecondContactRoleControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/contacts/SecondContactRoleControllerSpec.scala
@@ -50,7 +50,7 @@ class SecondContactRoleControllerSpec extends SpecBase {
   class TestContext(registrationData: Registration) {
     val controller = new SecondContactRoleController(
       mcc,
-      fakeAuthorisedAction,
+      fakeAuthorisedActionWithEnrolmentCheck,
       fakeDataRetrievalAction(registrationData),
       mockEclRegistrationConnector,
       formProvider,


### PR DESCRIPTION
Authorised actions split into 2:

- One which checks if the ECL enrolment is already there
- One which does not check if the ECL enrolment is already there