### PR TITLE
ECL-194: Send registration submitted emails to primary and secondary contact

### DIFF
--- a/app/uk/gov/hmrc/economiccrimelevyregistration/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/config/AppConfig.scala
@@ -63,18 +63,22 @@ class AppConfig @Inject() (configuration: Configuration, servicesConfig: Service
   val eclRegistrationBaseUrl: String = servicesConfig.baseUrl("economic-crime-levy-registration")
   val eclReturnsBaseUrl: String      = servicesConfig.baseUrl("economic-crime-levy-returns")
 
-  val incorporatedEntityIdentificationFrontendUrl: String =
+  val incorporatedEntityIdentificationFrontendBaseUrl: String =
     servicesConfig.baseUrl("incorporated-entity-identification-frontend")
-  val soleTraderEntityIdentificationFrontendUrl: String   = servicesConfig.baseUrl("sole-trader-identification-frontend")
-  val partnershipEntityIdentificationFrontendUrl: String  = servicesConfig.baseUrl("partnership-identification-frontend")
+  val soleTraderEntityIdentificationFrontendBaseUrl: String   =
+    servicesConfig.baseUrl("sole-trader-identification-frontend")
+  val partnershipEntityIdentificationFrontendBaseUrl: String  =
+    servicesConfig.baseUrl("partnership-identification-frontend")
 
   val incorporatedEntityBvEnabled: Boolean = configuration.get[Boolean]("features.incorporatedEntityBvEnabled")
   val partnershipBvEnabled: Boolean        = configuration.get[Boolean]("features.partnershipBvEnabled")
   val soleTraderBvEnabled: Boolean         = configuration.get[Boolean]("features.soleTraderBvEnabled")
 
-  val enrolmentStoreProxyUrl: String = servicesConfig.baseUrl("enrolment-store-proxy")
+  val enrolmentStoreProxyBaseUrl: String = servicesConfig.baseUrl("enrolment-store-proxy")
 
-  val addressLookupFrontendUrl: String = servicesConfig.baseUrl("address-lookup-frontend")
+  val addressLookupFrontendBaseUrl: String = servicesConfig.baseUrl("address-lookup-frontend")
+
+  val emailBaseUrl: String = servicesConfig.baseUrl("email")
 
   val amlProfessionalBodySupervisors: Seq[String] = configuration.get[Seq[String]]("amlProfessionalBodySupervisors")
 }

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/AddressLookupFrontendConnector.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/AddressLookupFrontendConnector.scala
@@ -41,7 +41,7 @@ class AddressLookupFrontendConnectorImpl @Inject() (
   ec: ExecutionContext
 ) extends AddressLookupFrontendConnector
     with HttpErrorFunctions {
-  private val baseUrl = appConfig.addressLookupFrontendUrl
+  private val baseUrl = appConfig.addressLookupFrontendBaseUrl
 
   def initJourney(ukMode: Boolean)(implicit
     hc: HeaderCarrier

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/EclRegistrationConnector.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/EclRegistrationConnector.scala
@@ -45,10 +45,13 @@ class EclRegistrationConnector @Inject() (appConfig: AppConfig, httpClient: Http
 
   def deleteRegistration(internalId: String)(implicit hc: HeaderCarrier): Future[Unit] =
     httpClient
-      .DELETE[HttpResponse](
+      .DELETE[Either[UpstreamErrorResponse, HttpResponse]](
         s"$eclRegistrationUrl/registrations/$internalId"
       )
-      .map(_ => ())
+      .map {
+        case Left(e)  => throw e
+        case Right(_) => ()
+      }
 
   def getSubscriptionStatus(businessPartnerId: String)(implicit hc: HeaderCarrier): Future[EclSubscriptionStatus] =
     httpClient.GET[EclSubscriptionStatus](

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/EmailConnector.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/EmailConnector.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.economiccrimelevyregistration.connectors
+
+import uk.gov.hmrc.economiccrimelevyregistration.config.AppConfig
+import uk.gov.hmrc.economiccrimelevyregistration.models.email.{RegistrationSubmittedEmailParameters, RegistrationSubmittedEmailRequest}
+import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse, UpstreamErrorResponse}
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class EmailConnector @Inject() (appConfig: AppConfig, httpClient: HttpClient)(implicit
+  ec: ExecutionContext
+) {
+
+  private val sendEmailUrl: String = s"${appConfig.emailBaseUrl}/hmrc/email"
+
+  def sendRegistrationSubmittedEmail(
+    to: String,
+    registrationSubmittedEmailParameters: RegistrationSubmittedEmailParameters
+  )(implicit
+    hc: HeaderCarrier
+  ): Future[Unit] =
+    httpClient
+      .POST[RegistrationSubmittedEmailRequest, Either[UpstreamErrorResponse, HttpResponse]](
+        sendEmailUrl,
+        RegistrationSubmittedEmailRequest(
+          to = to,
+          parameters = registrationSubmittedEmailParameters
+        )
+      )
+      .map {
+        case Left(e)  => throw e
+        case Right(_) => ()
+      }
+
+}

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/EmailConnector.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/EmailConnector.scala
@@ -41,7 +41,7 @@ class EmailConnector @Inject() (appConfig: AppConfig, httpClient: HttpClient)(im
       .POST[RegistrationSubmittedEmailRequest, Either[UpstreamErrorResponse, HttpResponse]](
         sendEmailUrl,
         RegistrationSubmittedEmailRequest(
-          to = to,
+          to = Seq(to),
           parameters = registrationSubmittedEmailParameters
         )
       )

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/EnrolmentStoreProxyConnector.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/EnrolmentStoreProxyConnector.scala
@@ -29,7 +29,7 @@ class EnrolmentStoreProxyConnector @Inject() (appConfig: AppConfig, httpClient: 
   ec: ExecutionContext
 ) {
 
-  private val enrolmentStoreUrl: String = s"${appConfig.enrolmentStoreProxyUrl}/enrolment-store"
+  private val enrolmentStoreUrl: String = s"${appConfig.enrolmentStoreProxyBaseUrl}/enrolment-store"
 
   def getEnrolmentsForGroup(groupId: String)(implicit hc: HeaderCarrier): Future[Option[GroupEnrolmentsResponse]] =
     httpClient.GET[Option[GroupEnrolmentsResponse]](

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/IncorporatedEntityIdentificationFrontendConnector.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/IncorporatedEntityIdentificationFrontendConnector.scala
@@ -38,7 +38,7 @@ class IncorporatedEntityIdentificationFrontendConnectorImpl @Inject() (
   ec: ExecutionContext
 ) extends IncorporatedEntityIdentificationFrontendConnector {
   private val apiUrl =
-    s"${appConfig.incorporatedEntityIdentificationFrontendUrl}/incorporated-entity-identification/api"
+    s"${appConfig.incorporatedEntityIdentificationFrontendBaseUrl}/incorporated-entity-identification/api"
 
   def createLimitedCompanyJourney()(implicit
     hc: HeaderCarrier

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/PartnershipIdentificationFrontendConnector.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/PartnershipIdentificationFrontendConnector.scala
@@ -42,7 +42,7 @@ class PartnershipIdentificationFrontendConnectorImpl @Inject() (
   val messagesApi: MessagesApi,
   ec: ExecutionContext
 ) extends PartnershipIdentificationFrontendConnector {
-  private val apiUrl = s"${appConfig.partnershipEntityIdentificationFrontendUrl}/partnership-identification/api"
+  private val apiUrl = s"${appConfig.partnershipEntityIdentificationFrontendBaseUrl}/partnership-identification/api"
 
   def createPartnershipJourney(
     partnershipType: EntityType

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/SoleTraderIdentificationFrontendConnector.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/SoleTraderIdentificationFrontendConnector.scala
@@ -40,7 +40,7 @@ class SoleTraderIdentificationFrontendConnectorImpl @Inject() (
   val messagesApi: MessagesApi,
   ec: ExecutionContext
 ) extends SoleTraderIdentificationFrontendConnector {
-  private val apiUrl = s"${appConfig.soleTraderEntityIdentificationFrontendUrl}/sole-trader-identification/api"
+  private val apiUrl = s"${appConfig.soleTraderEntityIdentificationFrontendBaseUrl}/sole-trader-identification/api"
 
   def createSoleTraderJourney()(implicit
     hc: HeaderCarrier

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/CheckYourAnswersController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/CheckYourAnswersController.scala
@@ -22,6 +22,7 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.economiccrimelevyregistration.connectors.EclRegistrationConnector
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.{AuthorisedActionWithEnrolmentCheck, DataRetrievalAction, ValidatedRegistrationAction}
 import uk.gov.hmrc.economiccrimelevyregistration.models.SessionKeys
+import uk.gov.hmrc.economiccrimelevyregistration.services.EmailService
 import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.checkAnswers._
 import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.govuk.summarylist._
 import uk.gov.hmrc.economiccrimelevyregistration.views.html.CheckYourAnswersView
@@ -39,7 +40,8 @@ class CheckYourAnswersController @Inject() (
   eclRegistrationConnector: EclRegistrationConnector,
   val controllerComponents: MessagesControllerComponents,
   view: CheckYourAnswersView,
-  validateRegistrationData: ValidatedRegistrationAction
+  validateRegistrationData: ValidatedRegistrationAction,
+  emailService: EmailService
 )(implicit ec: ExecutionContext)
     extends FrontendBaseController
     with I18nSupport {
@@ -84,10 +86,14 @@ class CheckYourAnswersController @Inject() (
   def onSubmit(): Action[AnyContent] = (authorise andThen getRegistrationData).async { implicit request =>
     eclRegistrationConnector
       .submitRegistration(request.internalId)
-      .map(rs =>
-        Redirect(routes.RegistrationSubmittedController.onPageLoad()).withSession(
-          request.session + (SessionKeys.EclReference -> rs.eclReference)
-        )
+      .flatMap(response =>
+        emailService
+          .sendRegistrationSubmittedEmails(request.registration.contacts, response.eclReference)
+          .map(_ =>
+            Redirect(routes.RegistrationSubmittedController.onPageLoad()).withSession(
+              request.session + (SessionKeys.EclReference -> response.eclReference)
+            )
+          )
       )
   }
 }

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/models/email/RegistrationSubmittedEmailRequest.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/models/email/RegistrationSubmittedEmailRequest.scala
@@ -26,12 +26,13 @@ object RegistrationSubmittedEmailParameters {
 
 final case class RegistrationSubmittedEmailRequest(
   to: Seq[String],
-  templateId: String = "ecl_registration_submitted",
+  templateId: String = RegistrationSubmittedEmailRequest.TemplateId,
   parameters: RegistrationSubmittedEmailParameters,
   force: Boolean = false,
   eventUrl: Option[String] = None
 )
 
 object RegistrationSubmittedEmailRequest {
+  val TemplateId: String                                          = "ecl_registration_submitted"
   implicit val format: OFormat[RegistrationSubmittedEmailRequest] = Json.format[RegistrationSubmittedEmailRequest]
 }

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/models/email/RegistrationSubmittedEmailRequest.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/models/email/RegistrationSubmittedEmailRequest.scala
@@ -25,7 +25,7 @@ object RegistrationSubmittedEmailParameters {
 }
 
 final case class RegistrationSubmittedEmailRequest(
-  to: String,
+  to: Seq[String],
   templateId: String = "ecl_registration_submitted",
   parameters: RegistrationSubmittedEmailParameters,
   force: Boolean = false,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/models/email/RegistrationSubmittedEmailRequest.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/models/email/RegistrationSubmittedEmailRequest.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.economiccrimelevyregistration.models.email
+
+import play.api.libs.json.{Json, OFormat}
+
+final case class RegistrationSubmittedEmailParameters(name: String, eclRegistrationReference: String, dateDue: String)
+
+object RegistrationSubmittedEmailParameters {
+  implicit val format: OFormat[RegistrationSubmittedEmailParameters] = Json.format[RegistrationSubmittedEmailParameters]
+}
+
+final case class RegistrationSubmittedEmailRequest(
+  to: String,
+  templateId: String = "ecl_registration_submitted",
+  parameters: RegistrationSubmittedEmailParameters,
+  force: Boolean = false,
+  eventUrl: Option[String] = None
+)
+
+object RegistrationSubmittedEmailRequest {
+  implicit val format: OFormat[RegistrationSubmittedEmailRequest] = Json.format[RegistrationSubmittedEmailRequest]
+}

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/services/EmailService.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/services/EmailService.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.economiccrimelevyregistration.services
+
+import play.api.i18n.Messages
+import uk.gov.hmrc.economiccrimelevyregistration.connectors.EmailConnector
+import uk.gov.hmrc.economiccrimelevyregistration.models.Contacts
+import uk.gov.hmrc.economiccrimelevyregistration.models.email.RegistrationSubmittedEmailParameters
+import uk.gov.hmrc.economiccrimelevyregistration.utils.EclTaxYear
+import uk.gov.hmrc.economiccrimelevyregistration.views.ViewUtils
+import uk.gov.hmrc.http.HeaderCarrier
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class EmailService @Inject() (emailConnector: EmailConnector)(implicit
+  ec: ExecutionContext
+) {
+
+  def sendRegistrationSubmittedEmails(contacts: Contacts, eclRegistrationReference: String)(implicit
+    hc: HeaderCarrier,
+    messages: Messages
+  ): Future[Unit] = {
+    val eclDueDate = ViewUtils.formatLocalDate(EclTaxYear.dueDate)
+
+    def sendEmail(name: String, email: String): Future[Unit] =
+      emailConnector.sendRegistrationSubmittedEmail(
+        email,
+        RegistrationSubmittedEmailParameters(
+          name = name,
+          eclRegistrationReference = eclRegistrationReference,
+          eclDueDate
+        )
+      )
+
+    (
+      contacts.firstContactDetails.name,
+      contacts.firstContactDetails.emailAddress,
+      contacts.secondContactDetails.name,
+      contacts.secondContactDetails.emailAddress
+    ) match {
+      case (Some(firstContactName), Some(firstContactEmail), Some(secondContactName), Some(secondContactEmail)) =>
+        for {
+          _ <- sendEmail(firstContactName, firstContactEmail)
+          _ <- sendEmail(secondContactName, secondContactEmail)
+        } yield ()
+      case (Some(firstContactName), Some(firstContactEmail), None, None)                                        =>
+        sendEmail(firstContactName, firstContactEmail)
+      case _                                                                                                    => throw new IllegalStateException("Invalid contact details")
+    }
+
+  }
+}

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/services/EmailService.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/services/EmailService.scala
@@ -35,7 +35,7 @@ class EmailService @Inject() (emailConnector: EmailConnector)(implicit
     hc: HeaderCarrier,
     messages: Messages
   ): Future[Unit] = {
-    val eclDueDate = ViewUtils.formatLocalDate(EclTaxYear.dueDate)
+    val eclDueDate = ViewUtils.formatLocalDate(EclTaxYear.dueDate, translate = false)
 
     def sendEmail(name: String, email: String): Future[Unit] =
       emailConnector.sendRegistrationSubmittedEmail(

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/ViewUtils.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/ViewUtils.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.views
 
+import com.ibm.icu.text.SimpleDateFormat
 import play.api.data.Form
 import play.api.i18n.Messages
 
@@ -49,13 +50,17 @@ object ViewUtils {
     s"$day $month $year"
   }
 
-  def formatLocalDate(localDate: LocalDate)(implicit messages: Messages): String = {
-    val day   = localDate.getDayOfMonth
-    val month = messages(s"date.month.${localDate.getMonthValue}")
-    val year  = localDate.getYear
+  def formatLocalDate(localDate: LocalDate, translate: Boolean = true)(implicit messages: Messages): String =
+    if (translate) {
+      val day   = localDate.getDayOfMonth
+      val month = messages(s"date.month.${localDate.getMonthValue}")
+      val year  = localDate.getYear
 
-    s"$day $month $year"
-  }
+      s"$day $month $year"
+    } else {
+      val formatter = new SimpleDateFormat("d MMMM yyyy")
+      formatter.format(Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant))
+    }
 
   def formatMoney(amount: Number): String = {
     val formatter = NumberFormat.getNumberInstance

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -92,6 +92,12 @@ microservice {
       host = localhost
       port = 9028
     }
+
+    email {
+      protocol = http
+      host = localhost
+      port = 8300
+    }
   }
 }
 

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/CheckYourAnswersISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/CheckYourAnswersISpec.scala
@@ -81,7 +81,7 @@ class CheckYourAnswersISpec extends ISpecBase with AuthorisedBehaviour {
           parameters = RegistrationSubmittedEmailParameters(
             name = firstContactName,
             eclRegistrationReference = eclReference,
-            dateDue = ViewUtils.formatLocalDate(EclTaxYear.dueDate)(messagesApi.preferred(Seq(Languages.english)))
+            dateDue = ViewUtils.formatLocalDate(EclTaxYear.dueDate, translate = false)(messagesApi.preferred(Seq(Languages.english)))
           )
         )
       )

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/CheckYourAnswersISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/CheckYourAnswersISpec.scala
@@ -6,8 +6,11 @@ import uk.gov.hmrc.economiccrimelevyregistration.base.ISpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.behaviours.AuthorisedBehaviour
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.routes
 import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
-import uk.gov.hmrc.economiccrimelevyregistration.models.Registration
+import uk.gov.hmrc.economiccrimelevyregistration.models.email.{RegistrationSubmittedEmailParameters, RegistrationSubmittedEmailRequest}
 import uk.gov.hmrc.economiccrimelevyregistration.models.errors.DataValidationErrors
+import uk.gov.hmrc.economiccrimelevyregistration.models.{ContactDetails, Contacts, Languages, Registration}
+import uk.gov.hmrc.economiccrimelevyregistration.utils.EclTaxYear
+import uk.gov.hmrc.economiccrimelevyregistration.views.ViewUtils
 
 class CheckYourAnswersISpec extends ISpecBase with AuthorisedBehaviour {
 
@@ -53,12 +56,35 @@ class CheckYourAnswersISpec extends ISpecBase with AuthorisedBehaviour {
     "redirect to the registration submitted page after submitting the registration successfully" in {
       stubAuthorisedWithNoGroupEnrolment()
 
-      val registration = random[Registration]
-      val eclReference = random[String]
+      val registration      = random[Registration]
+      val eclReference      = random[String]
+      val contactDetails    = random[ContactDetails]
+      val firstContactName  = random[String]
+      val firstContactEmail = random[String]
 
-      stubGetRegistration(registration)
+      val registrationWithOneContact = registration.copy(contacts =
+        Contacts(
+          firstContactDetails =
+            contactDetails.copy(name = Some(firstContactName), emailAddress = Some(firstContactEmail)),
+          secondContact = Some(false),
+          secondContactDetails = ContactDetails(None, None, None, None)
+        )
+      )
+
+      stubGetRegistration(registrationWithOneContact)
 
       stubSubmitRegistration(eclReference)
+
+      stubSendRegistrationSubmittedEmail(
+        RegistrationSubmittedEmailRequest(
+          to = Seq(firstContactEmail),
+          parameters = RegistrationSubmittedEmailParameters(
+            name = firstContactName,
+            eclRegistrationReference = eclReference,
+            dateDue = ViewUtils.formatLocalDate(EclTaxYear.dueDate)(messagesApi.preferred(Seq(Languages.english)))
+          )
+        )
+      )
 
       val result = callRoute(FakeRequest(routes.CheckYourAnswersController.onSubmit()))
 

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/base/EmailStubs.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/base/EmailStubs.scala
@@ -1,0 +1,26 @@
+package uk.gov.hmrc.economiccrimelevyregistration.base
+
+import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import play.api.http.Status.ACCEPTED
+import play.api.libs.json.Json
+import uk.gov.hmrc.economiccrimelevyregistration.base.WireMockHelper._
+import uk.gov.hmrc.economiccrimelevyregistration.models.email.RegistrationSubmittedEmailRequest
+
+trait EmailStubs { self: WireMockStubs =>
+
+  def stubSendRegistrationSubmittedEmail(
+    registrationSubmittedEmailRequest: RegistrationSubmittedEmailRequest
+  ): StubMapping =
+    stub(
+      post(urlEqualTo("/hmrc/email"))
+        .withRequestBody(
+          equalToJson(
+            Json.toJson(registrationSubmittedEmailRequest).toString()
+          )
+        ),
+      aResponse()
+        .withStatus(ACCEPTED)
+    )
+
+}

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/base/ISpecBase.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/base/ISpecBase.scala
@@ -61,7 +61,8 @@ abstract class ISpecBase
     "sole-trader-identification-frontend",
     "partnership-identification-frontend",
     "address-lookup-frontend",
-    "enrolment-store-proxy"
+    "enrolment-store-proxy",
+    "email"
   )
 
   val contextPath: String = "register-for-the-economic-crime-levy"

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/base/WireMockStubs.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/base/WireMockStubs.scala
@@ -15,7 +15,8 @@ trait WireMockStubs
     with AlfStubs
     with EclRegistrationStubs
     with EclReturnStubs
-    with EnrolmentStoreProxyStubs {
+    with EnrolmentStoreProxyStubs
+    with EmailStubs {
 
   def stubAuthorisedWithNoGroupEnrolment(): StubMapping = {
     stubAuthorised()

--- a/test-common/uk/gov/hmrc/economiccrimelevyregistration/EclTestData.scala
+++ b/test-common/uk/gov/hmrc/economiccrimelevyregistration/EclTestData.scala
@@ -31,8 +31,6 @@ import java.time.{Instant, LocalDate}
 
 final case class PartnershipType(entityType: EntityType)
 
-final case class ValidRegistration(registration: Registration)
-
 final case class EnrolmentsWithEcl(enrolments: Enrolments)
 
 final case class EnrolmentsWithoutEcl(enrolments: Enrolments)

--- a/test-common/uk/gov/hmrc/economiccrimelevyregistration/generators/CachedArbitraries.scala
+++ b/test-common/uk/gov/hmrc/economiccrimelevyregistration/generators/CachedArbitraries.scala
@@ -16,37 +16,39 @@
 
 package uk.gov.hmrc.economiccrimelevyregistration.generators
 
-import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
 import org.scalacheck.Arbitrary
 import org.scalacheck.derive.MkArbitrary
 import uk.gov.hmrc.economiccrimelevyregistration.EclTestData
 import uk.gov.hmrc.economiccrimelevyregistration.models.addresslookup.AlfAddressData
 import uk.gov.hmrc.economiccrimelevyregistration.models.eacd.GroupEnrolmentsResponse
+import uk.gov.hmrc.economiccrimelevyregistration.models.email.RegistrationSubmittedEmailParameters
 import uk.gov.hmrc.economiccrimelevyregistration.models.errors.DataValidationErrors
-import uk.gov.hmrc.economiccrimelevyregistration.models.grs.{GrsCreateJourneyResponse, IncorporatedEntityJourneyData, PartnershipEntityJourneyData, RegistrationStatus, SoleTraderEntityJourneyData, VerificationStatus}
-import uk.gov.hmrc.economiccrimelevyregistration.models.{AmlSupervisorType, BusinessSector, CalculateLiabilityRequest, CalculatedLiability, CreateEclSubscriptionResponse, EclSubscriptionStatus, EntityType, Registration, SubscriptionStatus}
+import uk.gov.hmrc.economiccrimelevyregistration.models.grs._
+import uk.gov.hmrc.economiccrimelevyregistration.models._
+import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
 
 object CachedArbitraries extends EclTestData {
 
   private def mkArb[T](implicit mkArb: MkArbitrary[T]): Arbitrary[T] = MkArbitrary[T].arbitrary
 
-  implicit lazy val arbRegistration: Arbitrary[Registration]                                   = mkArb
-  implicit lazy val arbBusinessSector: Arbitrary[BusinessSector]                               = mkArb
-  implicit lazy val arbVerificationStatus: Arbitrary[VerificationStatus]                       = mkArb
-  implicit lazy val arbRegistrationStatus: Arbitrary[RegistrationStatus]                       = mkArb
-  implicit lazy val arbSubscriptionStatus: Arbitrary[SubscriptionStatus]                       = mkArb
-  implicit lazy val arbEntityType: Arbitrary[EntityType]                                       = mkArb
-  implicit lazy val arbAmlSupervisorType: Arbitrary[AmlSupervisorType]                         = mkArb
-  implicit lazy val arbIncorporatedEntityJourneyData: Arbitrary[IncorporatedEntityJourneyData] = mkArb
-  implicit lazy val arbPartnershipEntityJourneyData: Arbitrary[PartnershipEntityJourneyData]   = mkArb
-  implicit lazy val arbSoleTraderEntityJourneyData: Arbitrary[SoleTraderEntityJourneyData]     = mkArb
-  implicit lazy val arbGrsCreateJourneyResponse: Arbitrary[GrsCreateJourneyResponse]           = mkArb
-  implicit lazy val arbGroupEnrolmentsResponse: Arbitrary[GroupEnrolmentsResponse]             = mkArb
-  implicit lazy val arbEclSubscriptionStatus: Arbitrary[EclSubscriptionStatus]                 = mkArb
-  implicit lazy val arbDataValidationErrors: Arbitrary[DataValidationErrors]                   = mkArb
-  implicit lazy val arbAlfAddressData: Arbitrary[AlfAddressData]                               = mkArb
-  implicit lazy val arbCalculatedLiability: Arbitrary[CalculatedLiability]                     = mkArb
-  implicit lazy val arbCalculateLiabilityRequest: Arbitrary[CalculateLiabilityRequest]         = mkArb
-  implicit lazy val arbCreateEclSubscriptionResponse: Arbitrary[CreateEclSubscriptionResponse] = mkArb
+  implicit lazy val arbRegistration: Arbitrary[Registration]                                            = mkArb
+  implicit lazy val arbBusinessSector: Arbitrary[BusinessSector]                                        = mkArb
+  implicit lazy val arbVerificationStatus: Arbitrary[VerificationStatus]                                = mkArb
+  implicit lazy val arbRegistrationStatus: Arbitrary[RegistrationStatus]                                = mkArb
+  implicit lazy val arbSubscriptionStatus: Arbitrary[SubscriptionStatus]                                = mkArb
+  implicit lazy val arbEntityType: Arbitrary[EntityType]                                                = mkArb
+  implicit lazy val arbAmlSupervisorType: Arbitrary[AmlSupervisorType]                                  = mkArb
+  implicit lazy val arbIncorporatedEntityJourneyData: Arbitrary[IncorporatedEntityJourneyData]          = mkArb
+  implicit lazy val arbPartnershipEntityJourneyData: Arbitrary[PartnershipEntityJourneyData]            = mkArb
+  implicit lazy val arbSoleTraderEntityJourneyData: Arbitrary[SoleTraderEntityJourneyData]              = mkArb
+  implicit lazy val arbGrsCreateJourneyResponse: Arbitrary[GrsCreateJourneyResponse]                    = mkArb
+  implicit lazy val arbGroupEnrolmentsResponse: Arbitrary[GroupEnrolmentsResponse]                      = mkArb
+  implicit lazy val arbEclSubscriptionStatus: Arbitrary[EclSubscriptionStatus]                          = mkArb
+  implicit lazy val arbDataValidationErrors: Arbitrary[DataValidationErrors]                            = mkArb
+  implicit lazy val arbAlfAddressData: Arbitrary[AlfAddressData]                                        = mkArb
+  implicit lazy val arbCalculatedLiability: Arbitrary[CalculatedLiability]                              = mkArb
+  implicit lazy val arbCalculateLiabilityRequest: Arbitrary[CalculateLiabilityRequest]                  = mkArb
+  implicit lazy val arbCreateEclSubscriptionResponse: Arbitrary[CreateEclSubscriptionResponse]          = mkArb
+  implicit lazy val arbRegistrationSubmittedParameters: Arbitrary[RegistrationSubmittedEmailParameters] = mkArb
 
 }

--- a/test-common/uk/gov/hmrc/economiccrimelevyregistration/generators/CachedArbitraries.scala
+++ b/test-common/uk/gov/hmrc/economiccrimelevyregistration/generators/CachedArbitraries.scala
@@ -51,5 +51,6 @@ object CachedArbitraries extends EclTestData {
   implicit lazy val arbCreateEclSubscriptionResponse: Arbitrary[CreateEclSubscriptionResponse]          = mkArb
   implicit lazy val arbRegistrationSubmittedParameters: Arbitrary[RegistrationSubmittedEmailParameters] = mkArb
   implicit lazy val arbContacts: Arbitrary[Contacts]                                                    = mkArb
+  implicit lazy val arbContactDetails: Arbitrary[ContactDetails]                                        = mkArb
 
 }

--- a/test-common/uk/gov/hmrc/economiccrimelevyregistration/generators/CachedArbitraries.scala
+++ b/test-common/uk/gov/hmrc/economiccrimelevyregistration/generators/CachedArbitraries.scala
@@ -19,12 +19,12 @@ package uk.gov.hmrc.economiccrimelevyregistration.generators
 import org.scalacheck.Arbitrary
 import org.scalacheck.derive.MkArbitrary
 import uk.gov.hmrc.economiccrimelevyregistration.EclTestData
+import uk.gov.hmrc.economiccrimelevyregistration.models._
 import uk.gov.hmrc.economiccrimelevyregistration.models.addresslookup.AlfAddressData
 import uk.gov.hmrc.economiccrimelevyregistration.models.eacd.GroupEnrolmentsResponse
 import uk.gov.hmrc.economiccrimelevyregistration.models.email.RegistrationSubmittedEmailParameters
 import uk.gov.hmrc.economiccrimelevyregistration.models.errors.DataValidationErrors
 import uk.gov.hmrc.economiccrimelevyregistration.models.grs._
-import uk.gov.hmrc.economiccrimelevyregistration.models._
 import com.danielasfregola.randomdatagenerator.RandomDataGenerator.derivedArbitrary
 
 object CachedArbitraries extends EclTestData {
@@ -50,5 +50,6 @@ object CachedArbitraries extends EclTestData {
   implicit lazy val arbCalculateLiabilityRequest: Arbitrary[CalculateLiabilityRequest]                  = mkArb
   implicit lazy val arbCreateEclSubscriptionResponse: Arbitrary[CreateEclSubscriptionResponse]          = mkArb
   implicit lazy val arbRegistrationSubmittedParameters: Arbitrary[RegistrationSubmittedEmailParameters] = mkArb
+  implicit lazy val arbContacts: Arbitrary[Contacts]                                                    = mkArb
 
 }

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/AddressLookupFrontendConnectorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/AddressLookupFrontendConnectorSpec.scala
@@ -31,7 +31,7 @@ import scala.concurrent.Future
 class AddressLookupFrontendConnectorSpec extends SpecBase {
   val mockHttpClient: HttpClient = mock[HttpClient]
   val connector                  = new AddressLookupFrontendConnectorImpl(appConfig, mockHttpClient)
-  val baseUrl                    = appConfig.addressLookupFrontendUrl
+  val baseUrl                    = appConfig.addressLookupFrontendBaseUrl
 
   "initJourney" should {
     val expectedUrl = s"$baseUrl/api/init"

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/EmailConnectorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/EmailConnectorSpec.scala
@@ -45,7 +45,7 @@ class EmailConnectorSpec extends SpecBase {
               ArgumentMatchers.eq(expectedUrl),
               ArgumentMatchers.eq(
                 RegistrationSubmittedEmailRequest(
-                  to,
+                  Seq(to),
                   templateId = "ecl_registration_submitted",
                   registrationSubmittedEmailParameters,
                   force = false,
@@ -81,7 +81,7 @@ class EmailConnectorSpec extends SpecBase {
               ArgumentMatchers.eq(expectedUrl),
               ArgumentMatchers.eq(
                 RegistrationSubmittedEmailRequest(
-                  to,
+                  Seq(to),
                   templateId = "ecl_registration_submitted",
                   registrationSubmittedEmailParameters,
                   force = false,
@@ -104,7 +104,7 @@ class EmailConnectorSpec extends SpecBase {
             ArgumentMatchers.eq(expectedUrl),
             ArgumentMatchers.eq(
               RegistrationSubmittedEmailRequest(
-                to,
+                Seq(to),
                 templateId = "ecl_registration_submitted",
                 registrationSubmittedEmailParameters,
                 force = false,

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/EmailConnectorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/EmailConnectorSpec.scala
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.economiccrimelevyregistration.connectors
+
+import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.any
+import play.api.http.Status.{ACCEPTED, INTERNAL_SERVER_ERROR}
+import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
+import uk.gov.hmrc.economiccrimelevyregistration.models.email.{RegistrationSubmittedEmailParameters, RegistrationSubmittedEmailRequest}
+import uk.gov.hmrc.http.{HttpClient, HttpResponse, UpstreamErrorResponse}
+
+import scala.concurrent.Future
+
+class EmailConnectorSpec extends SpecBase {
+
+  val mockHttpClient: HttpClient = mock[HttpClient]
+  val connector                  = new EmailConnector(appConfig, mockHttpClient)
+  val sendEmailUrl: String       = s"${appConfig.emailBaseUrl}/hmrc/email"
+
+  "sendRegistrationSubmittedEmail" should {
+    val expectedUrl = sendEmailUrl
+
+    "return unit when the http client returns a successful http response" in forAll {
+      (to: String, registrationSubmittedEmailParameters: RegistrationSubmittedEmailParameters) =>
+        val response = HttpResponse(ACCEPTED, "")
+
+        when(
+          mockHttpClient
+            .POST[RegistrationSubmittedEmailRequest, Either[UpstreamErrorResponse, HttpResponse]](
+              ArgumentMatchers.eq(expectedUrl),
+              ArgumentMatchers.eq(
+                RegistrationSubmittedEmailRequest(
+                  to,
+                  templateId = "ecl_registration_submitted",
+                  registrationSubmittedEmailParameters,
+                  force = false,
+                  None
+                )
+              ),
+              any()
+            )(any(), any(), any(), any())
+        )
+          .thenReturn(Future.successful(Right(response)))
+
+        val result: Unit = await(connector.sendRegistrationSubmittedEmail(to, registrationSubmittedEmailParameters))
+
+        result shouldBe ()
+
+        verify(mockHttpClient, times(1))
+          .POST[RegistrationSubmittedEmailRequest, Either[UpstreamErrorResponse, HttpResponse]](
+            ArgumentMatchers.eq(expectedUrl),
+            any(),
+            any()
+          )(any(), any(), any(), any())
+
+        reset(mockHttpClient)
+    }
+
+    "throw an exception when the http client returns an upstream error response" in forAll {
+      (to: String, registrationSubmittedEmailParameters: RegistrationSubmittedEmailParameters) =>
+        val response = UpstreamErrorResponse("Internal server error", INTERNAL_SERVER_ERROR)
+
+        when(
+          mockHttpClient
+            .POST[RegistrationSubmittedEmailRequest, Either[UpstreamErrorResponse, HttpResponse]](
+              ArgumentMatchers.eq(expectedUrl),
+              ArgumentMatchers.eq(
+                RegistrationSubmittedEmailRequest(
+                  to,
+                  templateId = "ecl_registration_submitted",
+                  registrationSubmittedEmailParameters,
+                  force = false,
+                  None
+                )
+              ),
+              any()
+            )(any(), any(), any(), any())
+        )
+          .thenReturn(Future.successful(Left(response)))
+
+        val result: UpstreamErrorResponse = intercept[UpstreamErrorResponse] {
+          await(connector.sendRegistrationSubmittedEmail(to, registrationSubmittedEmailParameters))
+        }
+
+        result.getMessage shouldBe "Internal server error"
+
+        verify(mockHttpClient, times(1))
+          .POST[RegistrationSubmittedEmailRequest, Either[UpstreamErrorResponse, HttpResponse]](
+            ArgumentMatchers.eq(expectedUrl),
+            ArgumentMatchers.eq(
+              RegistrationSubmittedEmailRequest(
+                to,
+                templateId = "ecl_registration_submitted",
+                registrationSubmittedEmailParameters,
+                force = false,
+                None
+              )
+            ),
+            any()
+          )(any(), any(), any(), any())
+
+        reset(mockHttpClient)
+    }
+  }
+}

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/EmailConnectorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/EmailConnectorSpec.scala
@@ -46,7 +46,7 @@ class EmailConnectorSpec extends SpecBase {
               ArgumentMatchers.eq(
                 RegistrationSubmittedEmailRequest(
                   Seq(to),
-                  templateId = "ecl_registration_submitted",
+                  templateId = RegistrationSubmittedEmailRequest.TemplateId,
                   registrationSubmittedEmailParameters,
                   force = false,
                   None
@@ -82,7 +82,7 @@ class EmailConnectorSpec extends SpecBase {
               ArgumentMatchers.eq(
                 RegistrationSubmittedEmailRequest(
                   Seq(to),
-                  templateId = "ecl_registration_submitted",
+                  templateId = RegistrationSubmittedEmailRequest.TemplateId,
                   registrationSubmittedEmailParameters,
                   force = false,
                   None
@@ -105,7 +105,7 @@ class EmailConnectorSpec extends SpecBase {
             ArgumentMatchers.eq(
               RegistrationSubmittedEmailRequest(
                 Seq(to),
-                templateId = "ecl_registration_submitted",
+                templateId = RegistrationSubmittedEmailRequest.TemplateId,
                 registrationSubmittedEmailParameters,
                 force = false,
                 None

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/EnrolmentStoreProxyConnectorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/EnrolmentStoreProxyConnectorSpec.scala
@@ -29,7 +29,7 @@ class EnrolmentStoreProxyConnectorSpec extends SpecBase {
 
   val mockHttpClient: HttpClient = mock[HttpClient]
   val connector                  = new EnrolmentStoreProxyConnector(appConfig, mockHttpClient)
-  val enrolmentStoreUrl: String  = s"${appConfig.enrolmentStoreProxyUrl}/enrolment-store"
+  val enrolmentStoreUrl: String  = s"${appConfig.enrolmentStoreProxyBaseUrl}/enrolment-store"
 
   "getEnrolmentsForGroup" should {
 

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/IncorporatedEntityIdentificationFrontendConnectorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/IncorporatedEntityIdentificationFrontendConnectorSpec.scala
@@ -28,7 +28,7 @@ import scala.concurrent.Future
 class IncorporatedEntityIdentificationFrontendConnectorSpec extends SpecBase {
   val mockHttpClient: HttpClient = mock[HttpClient]
   val connector                  = new IncorporatedEntityIdentificationFrontendConnectorImpl(appConfig, mockHttpClient)
-  val apiUrl                     = s"${appConfig.incorporatedEntityIdentificationFrontendUrl}/incorporated-entity-identification/api"
+  val apiUrl                     = s"${appConfig.incorporatedEntityIdentificationFrontendBaseUrl}/incorporated-entity-identification/api"
 
   "createLimitedCompanyJourney" should {
     "return a GRS create journey response for the given request when the http client returns a GRS create journey response for the given request" in forAll {

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/PartnershipIdentificationFrontendConnectorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/PartnershipIdentificationFrontendConnectorSpec.scala
@@ -30,7 +30,7 @@ import scala.concurrent.Future
 class PartnershipIdentificationFrontendConnectorSpec extends SpecBase {
   val mockHttpClient: HttpClient = mock[HttpClient]
   val connector                  = new PartnershipIdentificationFrontendConnectorImpl(appConfig, mockHttpClient)
-  val apiUrl                     = s"${appConfig.partnershipEntityIdentificationFrontendUrl}/partnership-identification/api"
+  val apiUrl                     = s"${appConfig.partnershipEntityIdentificationFrontendBaseUrl}/partnership-identification/api"
 
   "createPartnershipJourney" should {
     "return a GRS create journey response for the given request when the http client returns a GRS create journey response for the given request" in forAll {

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/SoleTraderIdentificationFrontendConnectorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/SoleTraderIdentificationFrontendConnectorSpec.scala
@@ -28,7 +28,7 @@ import scala.concurrent.Future
 class SoleTraderIdentificationFrontendConnectorSpec extends SpecBase {
   val mockHttpClient: HttpClient = mock[HttpClient]
   val connector                  = new SoleTraderIdentificationFrontendConnectorImpl(appConfig, mockHttpClient)
-  val apiUrl                     = s"${appConfig.soleTraderEntityIdentificationFrontendUrl}/sole-trader-identification/api"
+  val apiUrl                     = s"${appConfig.soleTraderEntityIdentificationFrontendBaseUrl}/sole-trader-identification/api"
 
   "createSoleTraderJourney" should {
     "return a GRS create journey response for the given request when the http client returns a GRS create journey response for the given request" in forAll {

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/services/EmailServiceSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/services/EmailServiceSpec.scala
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.economiccrimelevyregistration.services
+
+import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.any
+import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
+import uk.gov.hmrc.economiccrimelevyregistration.connectors.EmailConnector
+import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
+import uk.gov.hmrc.economiccrimelevyregistration.models.email.RegistrationSubmittedEmailParameters
+import uk.gov.hmrc.economiccrimelevyregistration.models.{ContactDetails, Contacts}
+import uk.gov.hmrc.economiccrimelevyregistration.utils.EclTaxYear
+import uk.gov.hmrc.economiccrimelevyregistration.views.ViewUtils
+
+import scala.concurrent.Future
+
+class EmailServiceSpec extends SpecBase {
+
+  val mockEmailConnector: EmailConnector = mock[EmailConnector]
+  val service                            = new EmailService(mockEmailConnector)
+
+  "sendRegistrationSubmittedEmails" should {
+    "send an email for the first contact and return unit" in forAll {
+      (contacts: Contacts, firstContactName: String, firstContactEmail: String, eclRegistrationReference: String) =>
+        val updatedContacts = contacts.copy(
+          firstContactDetails =
+            contacts.firstContactDetails.copy(name = Some(firstContactName), emailAddress = Some(firstContactEmail)),
+          secondContactDetails = ContactDetails(None, None, None, None)
+        )
+
+        val expectedFirstContactParams = RegistrationSubmittedEmailParameters(
+          firstContactName,
+          eclRegistrationReference,
+          ViewUtils.formatLocalDate(EclTaxYear.dueDate)(messages)
+        )
+
+        when(
+          mockEmailConnector
+            .sendRegistrationSubmittedEmail(
+              ArgumentMatchers.eq(firstContactEmail),
+              ArgumentMatchers.eq(expectedFirstContactParams)
+            )(any())
+        )
+          .thenReturn(Future.successful(()))
+
+        val result: Unit =
+          await(service.sendRegistrationSubmittedEmails(updatedContacts, eclRegistrationReference)(hc, messages))
+
+        result shouldBe ()
+
+        verify(mockEmailConnector, times(1))
+          .sendRegistrationSubmittedEmail(any(), any())(any())
+
+        reset(mockEmailConnector)
+    }
+
+    "send emails for the first and second contact and return unit" in forAll {
+      (
+        contacts: Contacts,
+        firstContactName: String,
+        firstContactEmail: String,
+        secondContactName: String,
+        secondContactEmail: String,
+        eclRegistrationReference: String
+      ) =>
+        val updatedContacts = contacts.copy(
+          firstContactDetails =
+            contacts.firstContactDetails.copy(name = Some(firstContactName), emailAddress = Some(firstContactEmail)),
+          secondContactDetails =
+            contacts.secondContactDetails.copy(name = Some(secondContactName), emailAddress = Some(secondContactEmail))
+        )
+
+        val eclDueDate = ViewUtils.formatLocalDate(EclTaxYear.dueDate)(messages)
+
+        val expectedFirstContactParams = RegistrationSubmittedEmailParameters(
+          firstContactName,
+          eclRegistrationReference,
+          eclDueDate
+        )
+
+        val expectedSecondContactParams = RegistrationSubmittedEmailParameters(
+          secondContactName,
+          eclRegistrationReference,
+          eclDueDate
+        )
+
+        when(
+          mockEmailConnector
+            .sendRegistrationSubmittedEmail(
+              ArgumentMatchers.eq(firstContactEmail),
+              ArgumentMatchers.eq(expectedFirstContactParams)
+            )(any())
+        )
+          .thenReturn(Future.successful(()))
+
+        when(
+          mockEmailConnector
+            .sendRegistrationSubmittedEmail(
+              ArgumentMatchers.eq(secondContactEmail),
+              ArgumentMatchers.eq(expectedSecondContactParams)
+            )(any())
+        )
+          .thenReturn(Future.successful(()))
+
+        val result: Unit =
+          await(service.sendRegistrationSubmittedEmails(updatedContacts, eclRegistrationReference)(hc, messages))
+
+        result shouldBe ()
+
+        verify(mockEmailConnector, times(2))
+          .sendRegistrationSubmittedEmail(any(), any())(any())
+
+        reset(mockEmailConnector)
+    }
+
+    "throw an IllegalStateException when the first contact details are missing" in forAll {
+      eclRegistrationReference: String =>
+        when(mockEmailConnector.sendRegistrationSubmittedEmail(any(), any())(any()))
+          .thenReturn(Future.successful(()))
+
+        val result = intercept[IllegalStateException] {
+          await(service.sendRegistrationSubmittedEmails(Contacts.empty, eclRegistrationReference)(hc, messages))
+        }
+
+        result.getMessage shouldBe "Invalid contact details"
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/services/EmailServiceSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/services/EmailServiceSpec.scala
@@ -45,7 +45,7 @@ class EmailServiceSpec extends SpecBase {
         val expectedFirstContactParams = RegistrationSubmittedEmailParameters(
           firstContactName,
           eclRegistrationReference,
-          ViewUtils.formatLocalDate(EclTaxYear.dueDate)(messages)
+          ViewUtils.formatLocalDate(EclTaxYear.dueDate, translate = false)(messages)
         )
 
         when(
@@ -84,7 +84,7 @@ class EmailServiceSpec extends SpecBase {
             contacts.secondContactDetails.copy(name = Some(secondContactName), emailAddress = Some(secondContactEmail))
         )
 
-        val eclDueDate = ViewUtils.formatLocalDate(EclTaxYear.dueDate)(messages)
+        val eclDueDate = ViewUtils.formatLocalDate(EclTaxYear.dueDate, translate = false)(messages)
 
         val expectedFirstContactParams = RegistrationSubmittedEmailParameters(
           firstContactName,

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/views/ViewUtilsSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/views/ViewUtilsSpec.scala
@@ -82,7 +82,7 @@ class ViewUtilsSpec extends SpecBase {
   }
 
   "formatMoney" should {
-    "format a moneyary amount with commas" in {
+    "format a monetary amount with commas" in {
       val amount = 1000000000
 
       ViewUtils.formatMoney(amount) shouldBe "1,000,000,000"

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/views/ViewUtilsSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/views/ViewUtilsSpec.scala
@@ -20,6 +20,9 @@ import play.api.data.Form
 import play.api.data.Forms.{single, text}
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 
+import java.time.{Instant, LocalDate}
+import java.util.Date
+
 class ViewUtilsSpec extends SpecBase {
 
   val testForm: Form[String] = Form(
@@ -53,6 +56,36 @@ class ViewUtilsSpec extends SpecBase {
       ViewUtils.title(testTitle, Some("Test Section"))(
         messages
       ) shouldBe "Test Title - Test Section - Register for the Economic Crime Levy - GOV.UK"
+    }
+  }
+
+  "formatDate" should {
+    "correctly format a date" in {
+      val date = Date.from(Instant.parse("2007-12-03T10:15:30.00Z"))
+
+      ViewUtils.formatDate(date)(messages) shouldBe "3 December 2007"
+    }
+  }
+
+  "formatLocalDate" should {
+    "correctly format a translated local date" in {
+      val localDate = LocalDate.parse("2007-12-03")
+
+      ViewUtils.formatLocalDate(localDate)(messages) shouldBe "3 December 2007"
+    }
+
+    "correctly format a non-translated local date" in {
+      val localDate = LocalDate.parse("2007-12-03")
+
+      ViewUtils.formatLocalDate(localDate, translate = false)(messages) shouldBe "3 December 2007"
+    }
+  }
+
+  "formatMoney" should {
+    "format a moneyary amount with commas" in {
+      val amount = 1000000000
+
+      ViewUtils.formatMoney(amount) shouldBe "1,000,000,000"
     }
   }
 


### PR DESCRIPTION
- This should not be merged until https://jira.tools.tax.service.gov.uk/browse/DC-4733 has been actioned by the DC team and https://github.com/hmrc/hmrc-email-renderer/pull/1001 has been merged and deployed to QA.