### PR TITLE
ECL-593: Corrected year displayed in success page and logic for determining whether user is liable for previous FY

### DIFF
--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationSubmittedController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegistrationSubmittedController.scala
@@ -23,6 +23,7 @@ import uk.gov.hmrc.economiccrimelevyregistration.models.{LiabilityYear, SessionK
 import uk.gov.hmrc.economiccrimelevyregistration.services.SessionService
 import uk.gov.hmrc.economiccrimelevyregistration.views.html.{OutOfSessionRegistrationSubmittedView, RegistrationSubmittedView}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import uk.gov.hmrc.time.TaxYear
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/models/LiabilityYear.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/models/LiabilityYear.scala
@@ -17,10 +17,12 @@
 package uk.gov.hmrc.economiccrimelevyregistration.models
 
 import play.api.libs.json.{Format, Json}
+import uk.gov.hmrc.time.TaxYear
 
 case class LiabilityYear(value: Int) {
-  val priorYearString: String = (value - 1).toString
-  val asString: String        = value.toString
+  val followingYear: String = (value + 1).toString
+  val asString: String      = value.toString
+  val isPreviousFY: Boolean = value == TaxYear.current.previous.startYear
 }
 
 object LiabilityYear {

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/OutOfSessionRegistrationSubmittedView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/OutOfSessionRegistrationSubmittedView.scala.html
@@ -40,8 +40,8 @@
 
     <p class="govuk-body">@messages("submitted.p3", formatLocalDate(EclTaxYear.dueDate))</p>
 
-    @if(liabilityYear.contains(TaxYear.current.previous.startYear)) {
-        <p class="govuk-body">@messages("submitted.liableForPreviousFY.p1", liabilityYear.get.asString, liabilityYear.get.priorYearString)</p>
+    @if(liabilityYear.exists(_.isPreviousFY)) {
+        <p class="govuk-body">@messages("submitted.liableForPreviousFY.p1", liabilityYear.get.asString, liabilityYear.get.followingYear)</p>
         <p class="govuk-body">@messages("submitted.liableForPreviousFY.p2")</p>
     }
 

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/RegistrationSubmittedView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/RegistrationSubmittedView.scala.html
@@ -48,8 +48,8 @@
 
     <p class="govuk-body">@messages("submitted.p3", formatLocalDate(EclTaxYear.dueDate))</p>
 
-    @if(liabilityYear.contains(TaxYear.current.previous.startYear)) {
-        <p class="govuk-body">@messages("submitted.liableForPreviousFY.p1", liabilityYear.get.asString, liabilityYear.get.priorYearString)</p>
+    @if(liabilityYear.exists(_.isPreviousFY)) {
+        <p class="govuk-body">@messages("submitted.liableForPreviousFY.p1", liabilityYear.get.asString, liabilityYear.get.followingYear)</p>
         <p class="govuk-body">@messages("submitted.liableForPreviousFY.p2")</p>
     }
 


### PR DESCRIPTION
Fix for bug found where the text informing the user to submit their return ASAP for the previous financial year was not being displayed
