### PR TITLE
ECL-839: Corrected liability dates following Financial Tax year instead of ECL Tax Year

### DIFF
--- a/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/EclCalculatorConnector.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/connectors/EclCalculatorConnector.scala
@@ -34,7 +34,7 @@ class EclCalculatorConnector @Inject() (appConfig: AppConfig, httpClient: HttpCl
     hc: HeaderCarrier
   ): Future[CalculatedLiability] = {
     val body = CalculateLiabilityRequest(
-      amlRegulatedActivityLength = EclTaxYear.YearInDays,
+      amlRegulatedActivityLength = EclTaxYear.yearInDays,
       relevantApLength = relevantApLength,
       ukRevenue = relevantApRevenue.toLong
     )

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/LiabilityBeforeCurrentYearController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/LiabilityBeforeCurrentYearController.scala
@@ -28,10 +28,10 @@ import uk.gov.hmrc.economiccrimelevyregistration.models._
 import uk.gov.hmrc.economiccrimelevyregistration.models.audit.{NotLiableReason, RegistrationNotLiableAuditEvent}
 import uk.gov.hmrc.economiccrimelevyregistration.models.errors.AuditError
 import uk.gov.hmrc.economiccrimelevyregistration.services.{AuditService, RegistrationAdditionalInfoService}
+import uk.gov.hmrc.economiccrimelevyregistration.utils.EclTaxYear
 import uk.gov.hmrc.economiccrimelevyregistration.views.html.{ErrorTemplate, LiabilityBeforeCurrentYearView}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
-import uk.gov.hmrc.time.TaxYear
 
 import javax.inject.Singleton
 import scala.concurrent.{ExecutionContext, Future}
@@ -162,8 +162,8 @@ class LiabilityBeforeCurrentYearController @Inject() (
     liableForPreviousFY: Boolean
   ): Option[LiabilityYear] =
     (liableForCurrentFY, liableForPreviousFY) match {
-      case (Some(_), true)     => Some(LiabilityYear(TaxYear.current.previous.startYear))
-      case (Some(true), false) => Some(LiabilityYear(TaxYear.current.currentYear))
+      case (Some(_), true)     => Some(LiabilityYear(EclTaxYear.current.previous.startYear))
+      case (Some(true), false) => Some(LiabilityYear(EclTaxYear.current.currentYear))
       case _                   => None
     }
 

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/LiabilityDateController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/LiabilityDateController.scala
@@ -25,9 +25,9 @@ import uk.gov.hmrc.economiccrimelevyregistration.forms.LiabilityDateFormProvider
 import uk.gov.hmrc.economiccrimelevyregistration.models.{EclRegistrationModel, LiabilityYear, Mode, SessionKeys}
 import uk.gov.hmrc.economiccrimelevyregistration.navigation.LiabilityDatePageNavigator
 import uk.gov.hmrc.economiccrimelevyregistration.services.RegistrationAdditionalInfoService
+import uk.gov.hmrc.economiccrimelevyregistration.utils.EclTaxYear
 import uk.gov.hmrc.economiccrimelevyregistration.views.html.{ErrorTemplate, LiabilityDateView}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
-import uk.gov.hmrc.time.TaxYear
 
 import java.time.LocalDate
 import javax.inject.Inject
@@ -63,7 +63,7 @@ class LiabilityDateController @Inject() (
         .fold(
           formWithErrors => Future.successful(BadRequest(view(mode, formWithErrors))),
           liabilityDate => {
-            val year           = TaxYear.taxYearFor(liabilityDate)
+            val year           = EclTaxYear.taxYearFor(liabilityDate)
             val registration   = request.registration
             val additionalInfo = request.additionalInfo.get.copy(
               liabilityStartDate = Some(liabilityDate),

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegisterForCurrentYearController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegisterForCurrentYearController.scala
@@ -79,9 +79,9 @@ class RegisterForCurrentYearController @Inject() (
                 view(
                   form.prepare(value.registeringForCurrentYear),
                   mode,
-                  s"${EclTaxYear.currentFinancialYear} to ${EclTaxYear.yearDue}",
+                  s"${EclTaxYear.currentStartYear().toString} to ${EclTaxYear.currentFinishYear().toString}",
                   EclTaxYear.currentFinancialYearStartDate,
-                  EclTaxYear.currentFinancialYearEndDate
+                  EclTaxYear.currentFinancialYearFinishDate
                 )
               )
             case None        =>
@@ -89,9 +89,9 @@ class RegisterForCurrentYearController @Inject() (
                 view(
                   form,
                   mode,
-                  s"${EclTaxYear.currentFinancialYear} to ${EclTaxYear.yearDue}",
+                  s"${EclTaxYear.currentStartYear().toString} to ${EclTaxYear.currentFinishYear().toString}",
                   EclTaxYear.currentFinancialYearStartDate,
-                  EclTaxYear.currentFinancialYearEndDate
+                  EclTaxYear.currentFinancialYearFinishDate
                 )
               )
           }
@@ -109,16 +109,16 @@ class RegisterForCurrentYearController @Inject() (
               view(
                 formWithErrors,
                 mode,
-                s"${EclTaxYear.currentFinancialYear} to ${EclTaxYear.yearDue}",
+                s"${EclTaxYear.currentStartYear().toString} to ${EclTaxYear.currentFinishYear().toString}",
                 EclTaxYear.currentFinancialYearStartDate,
-                EclTaxYear.currentFinancialYearEndDate
+                EclTaxYear.currentFinancialYearFinishDate
               )
             )
           ),
         answer =>
           (for {
             additionalInfo         <- registrationAdditionalInfoService.get(request.internalId).asResponseError
-            liabilityYear           = if (answer) Some(EclTaxYear.currentFinancialYear.toInt) else None
+            liabilityYear           = if (answer) Some(EclTaxYear.currentStartYear()) else None
             updatedAdditionalInfo   = additionalInfo.get.copy(
                                         registeringForCurrentYear = Some(answer),
                                         liabilityYear = liabilityYear.map(value => LiabilityYear(value))

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/deregister/DeregistrationRequestedController.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/controllers/deregister/DeregistrationRequestedController.scala
@@ -19,11 +19,10 @@ package uk.gov.hmrc.economiccrimelevyregistration.controllers.deregister
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.AuthorisedActionWithEnrolmentCheck
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.deregister.DeregistrationDataRetrievalAction
 import uk.gov.hmrc.economiccrimelevyregistration.controllers.{BaseController, ErrorHandler}
 import uk.gov.hmrc.economiccrimelevyregistration.models.SessionKeys
-import uk.gov.hmrc.economiccrimelevyregistration.services.deregister.DeregistrationService
 import uk.gov.hmrc.economiccrimelevyregistration.services.EclRegistrationService
+import uk.gov.hmrc.economiccrimelevyregistration.services.deregister.DeregistrationService
 import uk.gov.hmrc.economiccrimelevyregistration.views.html.ErrorTemplate
 import uk.gov.hmrc.economiccrimelevyregistration.views.html.deregister.DeregistrationRequestedView
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/forms/RegisterForCurrentYearFormProvider.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/forms/RegisterForCurrentYearFormProvider.scala
@@ -27,7 +27,7 @@ class RegisterForCurrentYearFormProvider extends Mappings {
       "value",
       boolean(
         "register.currentYear.error",
-        messageArgs = Seq(s"${EclTaxYear.currentFinancialYear} to ${EclTaxYear.yearDue}")
+        messageArgs = Seq(s"${EclTaxYear.currentStartYear().toString} to ${EclTaxYear.currentFinishYear().toString}")
       )
     )
   )

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/forms/mappings/MinMaxValues.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/forms/mappings/MinMaxValues.scala
@@ -21,5 +21,5 @@ import uk.gov.hmrc.economiccrimelevyregistration.utils.EclTaxYear
 import java.time.LocalDate
 
 object MinMaxValues {
-  val eclStartDate = LocalDate.of(EclTaxYear.initialYear, EclTaxYear.EclFyStartMonth, EclTaxYear.EclFyStartDay)
+  val eclStartDate: LocalDate = LocalDate.of(EclTaxYear.initialYear, EclTaxYear.startMonth, EclTaxYear.startDay)
 }

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/models/LiabilityYear.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/models/LiabilityYear.scala
@@ -17,14 +17,14 @@
 package uk.gov.hmrc.economiccrimelevyregistration.models
 
 import play.api.libs.json.{Format, Json}
-import uk.gov.hmrc.time.TaxYear
+import uk.gov.hmrc.economiccrimelevyregistration.utils.EclTaxYear
 
 case class LiabilityYear(value: Int) {
-  def currentTaxYear(): TaxYear = TaxYear.current
-  val followingYear: String     = (value + 1).toString
-  val asString: String          = value.toString
-  val isCurrentFY: Boolean      = value == currentTaxYear().startYear || value == currentTaxYear().finishYear
-  val isNotCurrentFY: Boolean   = !isCurrentFY
+  def currentTaxYear(): EclTaxYear = EclTaxYear.current
+  val followingYear: String        = (value + 1).toString
+  val asString: String             = value.toString
+  val isCurrentFY: Boolean         = value == currentTaxYear().startYear || value == currentTaxYear().finishYear
+  val isNotCurrentFY: Boolean      = !isCurrentFY
 
 }
 

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/services/EclCalculatorService.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/services/EclCalculatorService.scala
@@ -38,7 +38,7 @@ class EclCalculatorService @Inject() (
     registration.relevantApRevenue match {
       case Some(revenue) =>
         registration.relevantAp12Months match {
-          case Some(true)  => calculateLiabilityAmount(EclTaxYear.YearInDays, revenue)
+          case Some(true)  => calculateLiabilityAmount(EclTaxYear.yearInDays, revenue)
           case Some(false) =>
             registration.relevantApLength match {
               case Some(relevantApLength) => calculateLiabilityAmount(relevantApLength, revenue)

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/services/EmailService.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/services/EmailService.scala
@@ -26,7 +26,6 @@ import uk.gov.hmrc.economiccrimelevyregistration.models.{Contacts, EclAddress, E
 import uk.gov.hmrc.economiccrimelevyregistration.utils.EclTaxYear
 import uk.gov.hmrc.economiccrimelevyregistration.views.ViewUtils
 import uk.gov.hmrc.http.{HeaderCarrier, UpstreamErrorResponse}
-import uk.gov.hmrc.time.TaxYear
 
 import java.time.{LocalDate, ZoneOffset}
 import javax.inject.Inject
@@ -54,7 +53,7 @@ class EmailService @Inject() (emailConnector: EmailConnector)(implicit
     val previousFY       =
       additionalInfo.flatMap(_.liabilityYear.flatMap(year => if (year.isNotCurrentFY) Some(year.asString) else None))
     val currentFY        =
-      liableForCurrentFY.map(_ => TaxYear.current.currentYear.toString)
+      liableForCurrentFY.map(_ => EclTaxYear.current.currentYear.toString)
 
     def sendEmail(
       name: String,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/utils/EclCurrentTaxYear.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/utils/EclCurrentTaxYear.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.economiccrimelevyregistration.utils
+
+import java.time.{LocalDate, MonthDay, ZoneId}
+
+trait EclCurrentTaxYear {
+
+  private val startDay = 1
+  private val startMonth = 4
+  
+  final val ukTime: ZoneId = ZoneId.of("Europe/London")
+
+  private val startOfTaxYear = MonthDay.of(startMonth, startDay)
+
+  def now: () => LocalDate
+
+  final def firstDayOfTaxYear(year: Int): LocalDate = startOfTaxYear.atYear(year)
+
+  final def today: LocalDate = now()
+
+  final def taxYearFor(date: LocalDate): EclTaxYear = {
+    if (date isBefore firstDayOfTaxYear(date.getYear)) {
+      EclTaxYear(startYear = date.getYear - 1)
+    } else {
+      EclTaxYear(startYear = date.getYear)
+    }
+  }
+
+  final def current: EclTaxYear = taxYearFor(today)
+}

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/utils/EclCurrentTaxYear.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/utils/EclCurrentTaxYear.scala
@@ -20,9 +20,9 @@ import java.time.{LocalDate, MonthDay, ZoneId}
 
 trait EclCurrentTaxYear {
 
-  private val startDay = 1
+  private val startDay   = 1
   private val startMonth = 4
-  
+
   final val ukTime: ZoneId = ZoneId.of("Europe/London")
 
   private val startOfTaxYear = MonthDay.of(startMonth, startDay)
@@ -33,13 +33,12 @@ trait EclCurrentTaxYear {
 
   final def today: LocalDate = now()
 
-  final def taxYearFor(date: LocalDate): EclTaxYear = {
+  final def taxYearFor(date: LocalDate): EclTaxYear =
     if (date isBefore firstDayOfTaxYear(date.getYear)) {
       EclTaxYear(startYear = date.getYear - 1)
     } else {
       EclTaxYear(startYear = date.getYear)
     }
-  }
 
   final def current: EclTaxYear = taxYearFor(today)
 }

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/utils/EclTaxYear.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/utils/EclTaxYear.scala
@@ -23,32 +23,22 @@ case class EclTaxYear(startYear: Int) {
 
   lazy val finishYear: Int = startYear + 1
 
-  private def starts: LocalDate = EclTaxYear.firstDayOfTaxYear(startYear)
-
-  private lazy val finishes: LocalDate = LocalDate.of(finishYear, EclTaxYear.finishMonth, EclTaxYear.finishDay)
-
   def back(years: Int): EclTaxYear = EclTaxYear(startYear - years)
 
   lazy val previous: EclTaxYear = back(1)
 
   lazy val currentYear: Int = startYear
 
-  def forwards(years: Int): EclTaxYear = EclTaxYear(startYear + years)
-
-  lazy val next: EclTaxYear = forwards(1)
-
-  def contains(date: LocalDate): Boolean = !(date.isBefore(starts) || date.isAfter(finishes))
-
   override def toString = s"$startYear to $finishYear"
 }
 
 object EclTaxYear extends EclCurrentTaxYear with (Int => EclTaxYear) {
 
-  private val dayDue   = 30
-  private val monthDue = 9
+  private val dayDue           = 30
+  private val finishDay: Int   = 31
+  private val finishMonth: Int = 3
+  private val monthDue         = 9
 
-  val finishDay: Int   = 31
-  val finishMonth: Int = 3
   val startMonth: Int  = 4
   val startDay: Int    = 1
   val initialYear: Int = 2022

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/utils/EclTaxYear.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/utils/EclTaxYear.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,37 +19,66 @@ package uk.gov.hmrc.economiccrimelevyregistration.utils
 import java.time.LocalDate
 import scala.annotation.tailrec
 
-object EclTaxYear {
+case class EclTaxYear(startYear: Int) {
 
-  private def startYear     = LocalDate.now().getYear
-  private val MonthDue      = 9
-  private val DayDue        = 30
-  private val EclFyEndMonth = 3
-  val EclFyStartMonth       = 4
-  private val EclFyEndDay   = 31
-  val EclFyStartDay         = 1
-  val initialYear           = 2022
-  def dueDate: LocalDate    =
-    LocalDate.of(calculateYearDue(), MonthDue, DayDue)
+  lazy val finishYear: Int = startYear + 1
 
-  def yearDue: String              = calculateYearDue().toString
-  def currentFinancialYear: String = (yearDue.toInt - 1).toString
-  val YearInDays: Int              = 365
+  private def starts: LocalDate = EclTaxYear.firstDayOfTaxYear(startYear)
+
+  private lazy val finishes: LocalDate = LocalDate.of(finishYear, EclTaxYear.finishMonth, EclTaxYear.finishDay)
+
+  def back(years: Int): EclTaxYear = EclTaxYear(startYear - years)
+
+  lazy val previous: EclTaxYear = back(1)
+
+  lazy val currentYear: Int = startYear
+
+  def forwards(years: Int): EclTaxYear = EclTaxYear(startYear + years)
+
+  lazy val next: EclTaxYear = forwards(1)
+
+  def contains(date: LocalDate): Boolean = !(date.isBefore(starts) || date.isAfter(finishes))
+
+  override def toString = s"$startYear to $finishYear"
+}
+
+object EclTaxYear extends EclCurrentTaxYear with (Int => EclTaxYear) {
+
+  private val dayDue   = 30
+  private val monthDue = 9
+
+  val finishDay: Int   = 31
+  val finishMonth: Int = 3
+  val startMonth: Int  = 4
+  val startDay: Int    = 1
+  val initialYear: Int = 2022
+  val yearInDays: Int  = 365
+
+  override def now: () => LocalDate = () => LocalDate.now(ukTime)
 
   @tailrec
-  def calculateYearDue(yearDue: Int = startYear, currentDate: LocalDate = LocalDate.now()): Int =
-    if (currentDate.isAfter(LocalDate.of(yearDue, MonthDue, DayDue))) {
+  def calculateYearDue(yearDue: Int = currentStartYear(), currentDate: LocalDate = LocalDate.now()): Int =
+    if (currentDate.isAfter(LocalDate.of(yearDue, monthDue, dayDue))) {
       calculateYearDue(yearDue + 1, currentDate)
     } else {
       yearDue
     }
 
+  def currentFinishYear(): Int = EclTaxYear.current.finishYear
+
+  def currentStartYear(): Int = EclTaxYear.current.startYear
+
+  def currentFinancialYearFinishDate: LocalDate =
+    LocalDate.of(currentFinishYear(), finishMonth, finishDay)
+
   def currentFinancialYearStartDate: LocalDate =
-    LocalDate.of(currentFinancialYear.toInt, EclFyStartMonth, EclFyStartDay)
-  def currentFinancialYearEndDate: LocalDate   =
-    LocalDate.of(currentFinancialYear.toInt + 1, EclFyEndMonth, EclFyEndDay)
+    LocalDate.of(currentStartYear(), startMonth, startDay)
 
-  def currentFyStartYear: String = currentFinancialYearStartDate.getYear.toString
-  def currentFyEndYear: String   = currentFinancialYearEndDate.getYear.toString
+  def currentFyFinishYear: Int = currentFinancialYearFinishDate.getYear
 
+  def currentFyStartYear: Int = currentFinancialYearStartDate.getYear
+
+  def dueDate: LocalDate = LocalDate.of(calculateYearDue(), monthDue, dayDue)
+
+  def yearDue: Int = calculateYearDue()
 }

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/viewmodels/govuk/FieldsetFluency.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/viewmodels/govuk/FieldsetFluency.scala
@@ -20,7 +20,6 @@ import play.twirl.api.Html
 import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.LegendSize
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Content
 import uk.gov.hmrc.govukfrontend.views.viewmodels.fieldset.{Fieldset, Legend}
-import uk.gov.hmrc.govukfrontend.views.viewmodels.label.Label
 
 object fieldset extends FieldsetFluency
 

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/AgentCannotRegisterView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/AgentCannotRegisterView.scala.html
@@ -14,8 +14,10 @@
  * limitations under the License.
  *@
 
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
+
 @this(
-        layout: templates.Layout
+        layout: Layout
 )
 
 @()(implicit request: Request[_], messages: Messages)

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/AmendReasonView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/AmendReasonView.scala.html
@@ -14,8 +14,10 @@
  * limitations under the License.
  *@
 
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
+
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         formHelper: FormWithCSRF,
         govukErrorSummary: GovukErrorSummary,
         govukTextarea: GovukTextarea,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/AmendRegistrationStartView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/AmendRegistrationStartView.scala.html
@@ -15,9 +15,10 @@
  *@
 
 @import uk.gov.hmrc.economiccrimelevyregistration.models.RegistrationType.Amendment
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         button: GovukButton,
         table: GovukTable
 )

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/AmendmentRequestedView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/AmendmentRequestedView.scala.html
@@ -15,14 +15,16 @@
  *@
 
 @import uk.gov.hmrc.economiccrimelevyregistration.config.AppConfig
-@import uk.gov.hmrc.economiccrimelevyregistration.views.ViewUtils
-@import uk.gov.hmrc.economiccrimelevyregistration.models.RegistrationType.Amendment
 @import uk.gov.hmrc.economiccrimelevyregistration.models.EclAddress
+@import uk.gov.hmrc.economiccrimelevyregistration.models.RegistrationType.Amendment
 @import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.AddressViewModel
+@import uk.gov.hmrc.economiccrimelevyregistration.views.ViewUtils
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
+
 @import java.time.LocalDate
 
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         govukPanel: GovukPanel,
         appConfig: AppConfig
 )

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/AmlRegulatedActivityView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/AmlRegulatedActivityView.scala.html
@@ -16,9 +16,10 @@
 
 @import uk.gov.hmrc.economiccrimelevyregistration.utils.EclTaxYear
 @import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.LegendSize
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         formHelper: FormWithCSRF,
         errorSummary: GovukErrorSummary,
         radios: GovukRadios,
@@ -27,7 +28,7 @@
 
 @(form: Form[Boolean], mode: Mode)(implicit request: Request[_], messages: Messages)
 
-@layout(pageTitle = titleWithForm(form, messages("amlRegulatedActivity.title", EclTaxYear.currentFyStartYear, EclTaxYear.currentFyEndYear))) {
+@layout(pageTitle = titleWithForm(form, messages("amlRegulatedActivity.title", EclTaxYear.currentFyStartYear.toString, EclTaxYear.currentFyFinishYear.toString))) {
     @formHelper(action = AmlRegulatedActivityController.onSubmit(mode)) {
         @if(form.errors.nonEmpty) {
             @errorSummary(ErrorSummaryViewModel(form, errorLinkOverrides = Map("value" -> "yes")))
@@ -36,7 +37,7 @@
         @radios(
             RadiosViewModel(
                 field = form("value"),
-                legend = LegendViewModel(messages("amlRegulatedActivity.heading", EclTaxYear.currentFyStartYear, EclTaxYear.currentFyEndYear)).asPageHeading(LegendSize.Large),
+                legend = LegendViewModel(messages("amlRegulatedActivity.heading", EclTaxYear.currentFyStartYear.toString, EclTaxYear.currentFyFinishYear.toString)).asPageHeading(LegendSize.Large),
                 items = Seq(
                     RadioItem(
                         id = Some("yes"),

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/AmlSupervisorView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/AmlSupervisorView.scala.html
@@ -16,9 +16,10 @@
 
 @import uk.gov.hmrc.economiccrimelevyregistration.config.AppConfig
 @import uk.gov.hmrc.economiccrimelevyregistration.models.RegistrationType.Initial
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         formHelper: FormWithCSRF,
         errorSummary: GovukErrorSummary,
         radios: GovukRadios,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/AnswersAreInvalidView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/AnswersAreInvalidView.scala.html
@@ -14,8 +14,10 @@
  * limitations under the License.
  *@
 
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
+
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         button: GovukButton
 )
 
@@ -34,7 +36,7 @@
 
     @button(
         ButtonViewModel(messages("answersAreInvalid.button"))
-                .asLink(AmlRegulatedActivityController.onPageLoad(NormalMode).url)
+        .asLink(AmlRegulatedActivityController.onPageLoad(NormalMode).url)
     )
 
 }

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/AssistantCannotRegisterView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/AssistantCannotRegisterView.scala.html
@@ -14,8 +14,10 @@
  * limitations under the License.
  *@
 
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
+
 @this(
-        layout: templates.Layout
+        layout: Layout
 )
 
 @()(implicit request: Request[_], messages: Messages)

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/BusinessNameView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/BusinessNameView.scala.html
@@ -15,9 +15,10 @@
  *@
 
 @import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.InputWidth._
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout,
+        layout: Layout,
         formHelper: FormWithCSRF,
         govukErrorSummary: GovukErrorSummary,
         govukInput: GovukInput,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/BusinessSectorView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/BusinessSectorView.scala.html
@@ -15,10 +15,10 @@
  *@
 
 @import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.LegendSize
-@import uk.gov.hmrc.economiccrimelevyregistration.models.RegistrationType._
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         formHelper: FormWithCSRF,
         errorSummary: GovukErrorSummary,
         radios: GovukRadios,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/CancelRegistrationAmendmentView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/CancelRegistrationAmendmentView.scala.html
@@ -14,7 +14,6 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Empty
 @import uk.gov.hmrc.economiccrimelevyregistration.models.RegistrationType.Amendment
 @import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/CharityRegistrationNumberView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/CharityRegistrationNumberView.scala.html
@@ -14,10 +14,10 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.InputWidth._
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout,
+        layout: Layout,
         formHelper: FormWithCSRF,
         govukErrorSummary: GovukErrorSummary,
         govukInput: GovukInput,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/CheckYourAnswersView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/CheckYourAnswersView.scala.html
@@ -14,11 +14,12 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.checkAnswers._
 @import uk.gov.hmrc.economiccrimelevyregistration.controllers.routes
+@import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.checkAnswers._
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         formHelper: FormWithCSRF,
         govukSummaryList: GovukSummaryList,
         govukButton: GovukButton

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/CompanyRegistrationNumberView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/CompanyRegistrationNumberView.scala.html
@@ -14,10 +14,10 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.InputWidth._
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout,
+        layout: Layout,
         formHelper: FormWithCSRF,
         govukErrorSummary: GovukErrorSummary,
         govukInput: GovukInput,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/ConfirmContactAddressView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/ConfirmContactAddressView.scala.html
@@ -14,10 +14,10 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Empty
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         formHelper: FormWithCSRF,
         errorSummary: GovukErrorSummary,
         radios: GovukRadios,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/CtUtrPostcodeView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/CtUtrPostcodeView.scala.html
@@ -14,15 +14,13 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.components.GovukButton
-@import uk.gov.hmrc.govukfrontend.views.html.components.GovukInput
-@import uk.gov.hmrc.govukfrontend.views.html.components.GovukErrorSummary
-@import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
-@import uk.gov.hmrc.economiccrimelevyregistration.views.ViewUtils.titleWithForm
 @import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.InputWidth.Fixed20
+@import uk.gov.hmrc.economiccrimelevyregistration.views.ViewUtils.titleWithForm
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
+@import uk.gov.hmrc.govukfrontend.views.html.components.{FormWithCSRF, GovukButton, GovukErrorSummary, GovukInput}
 
 @this(
-        layout: uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout,
+        layout: Layout,
         formHelper: FormWithCSRF,
         govukErrorSummary: GovukErrorSummary,
         govukInput: GovukInput,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/CtUtrView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/CtUtrView.scala.html
@@ -14,16 +14,14 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.components.GovukButton
-@import uk.gov.hmrc.govukfrontend.views.html.components.GovukInput
-@import uk.gov.hmrc.govukfrontend.views.html.components.GovukErrorSummary
-@import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
 @import uk.gov.hmrc.economiccrimelevyregistration.models.Mode
-@import uk.gov.hmrc.economiccrimelevyregistration.views.ViewUtils.titleWithForm
 @import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.InputWidth.Fixed20
+@import uk.gov.hmrc.economiccrimelevyregistration.views.ViewUtils.titleWithForm
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
+@import uk.gov.hmrc.govukfrontend.views.html.components.{FormWithCSRF, GovukButton, GovukErrorSummary, GovukInput}
 
 @this(
-        layout: uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout,
+        layout: Layout,
         formHelper: FormWithCSRF,
         govukErrorSummary: GovukErrorSummary,
         govukInput: GovukInput,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/DoYouHaveCrnView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/DoYouHaveCrnView.scala.html
@@ -14,15 +14,15 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.components.GovukRadios
-@import uk.gov.hmrc.govukfrontend.views.viewmodels.radios.RadioItem
-@import uk.gov.hmrc.govukfrontend.views.html.components._
-@import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.LegendSize
 @import uk.gov.hmrc.economiccrimelevyregistration.models.Mode
+@import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.LegendSize
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
+@import uk.gov.hmrc.govukfrontend.views.html.components.{GovukRadios, _}
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.radios.RadioItem
 
 
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         radios: GovukRadios,
         button: GovukButton,
         formHelper: FormWithCSRF,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/DoYouHaveCtUtrView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/DoYouHaveCtUtrView.scala.html
@@ -14,15 +14,13 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.components.GovukRadios
-@import uk.gov.hmrc.govukfrontend.views.viewmodels.radios.RadioItem
-@import uk.gov.hmrc.govukfrontend.views.html.components._
-@import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.LegendSize
 @import uk.gov.hmrc.economiccrimelevyregistration.models.Mode
-
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
+@import uk.gov.hmrc.govukfrontend.views.html.components.{GovukRadios, _}
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.radios.RadioItem
 
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         radios: GovukRadios,
         button: GovukButton,
         formHelper: FormWithCSRF,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/DoYouHaveUtrView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/DoYouHaveUtrView.scala.html
@@ -19,10 +19,10 @@
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.LegendSize
 @import uk.gov.hmrc.economiccrimelevyregistration.models.Mode
-
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         radios: GovukRadios,
         button: GovukButton,
         formHelper: FormWithCSRF,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/EntityTypeView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/EntityTypeView.scala.html
@@ -16,9 +16,10 @@
 
 @import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.LegendSize
 @import uk.gov.hmrc.economiccrimelevyregistration.config.AppConfig
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         formHelper: FormWithCSRF,
         errorSummary: GovukErrorSummary,
         radios: GovukRadios,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/ErrorTemplate.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/ErrorTemplate.scala.html
@@ -14,8 +14,10 @@
  * limitations under the License.
  *@
 
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
+
 @this(
-    layout: templates.Layout
+    layout: Layout
 )
 
 @(pageTitle: String, heading: String, message: String)(implicit request: Request[_], messages: Messages)

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/FinancialConductAuthorityView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/FinancialConductAuthorityView.scala.html
@@ -15,9 +15,10 @@
  *@
 
 @import uk.gov.hmrc.economiccrimelevyregistration.config.AppConfig
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         appConfig: AppConfig
 )
 

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/GamblingCommissionView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/GamblingCommissionView.scala.html
@@ -15,9 +15,10 @@
  *@
 
 @import uk.gov.hmrc.economiccrimelevyregistration.config.AppConfig
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         appConfig: AppConfig
 )
 

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/GroupAlreadyEnrolledView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/GroupAlreadyEnrolledView.scala.html
@@ -14,9 +14,9 @@
  * limitations under the License.
  *@
 
-@this(
-        layout: templates.Layout
-)
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
+
+@this(layout: Layout)
 
 @(eclReferenceNumber: String, taxAndSchemeManagementUrl: String)(implicit request: Request[_], messages: Messages)
 

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/IsUkAddressView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/IsUkAddressView.scala.html
@@ -15,9 +15,10 @@
  *@
 
 @import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.LegendSize
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         formHelper: FormWithCSRF,
         errorSummary: GovukErrorSummary,
         radios: GovukRadios,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/LiabilityBeforeCurrentYearView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/LiabilityBeforeCurrentYearView.scala.html
@@ -14,22 +14,20 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.components.GovukRadios
-@import uk.gov.hmrc.govukfrontend.views.viewmodels.radios.RadioItem
-@import uk.gov.hmrc.govukfrontend.views.html.components._
-@import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.LegendSize
 @import uk.gov.hmrc.economiccrimelevyregistration.models.Mode
 @import uk.gov.hmrc.economiccrimelevyregistration.utils.EclTaxYear
-
-
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
+@import uk.gov.hmrc.govukfrontend.views.html.components.{GovukRadios, _}
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.radios.RadioItem
 
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         radios: GovukRadios,
         button: GovukButton,
         formHelper: FormWithCSRF,
         errorSummary: GovukErrorSummary
 )
+
 @(form: Form[Boolean], mode: Mode)(implicit request: Request[_], messages: Messages)
 
 @layout(
@@ -56,7 +54,7 @@
                     RadioItem(
                         id = Some("no"),
                         value = Some("false"),
-                        content = Text(messages("liabilityBeforeCurrentYear.no", s"${EclTaxYear.currentFinancialYear} to ${EclTaxYear.yearDue}"))
+                        content = Text(messages("liabilityBeforeCurrentYear.no", s"${EclTaxYear.currentStartYear().toString} to ${EclTaxYear.currentFinishYear().toString}"))
                     )
                 )
             )

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/LiabilityDateView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/LiabilityDateView.scala.html
@@ -14,12 +14,14 @@
  * limitations under the License.
  *@
 
-@import java.time.LocalDate
-@import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichDateInput
 @import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.LegendSize
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
+@import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichDateInput
+
+@import java.time.LocalDate
 
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         formHelper: FormWithCSRF,
         errorSummary: GovukErrorSummary,
         dateInput: GovukDateInput,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/NonUkCrnView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/NonUkCrnView.scala.html
@@ -14,10 +14,10 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.InputWidth._
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout,
+        layout: Layout,
         formHelper: FormWithCSRF,
         govukErrorSummary: GovukErrorSummary,
         govukInput: GovukInput,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/NotLiableView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/NotLiableView.scala.html
@@ -15,9 +15,10 @@
  *@
 
 @import uk.gov.hmrc.economiccrimelevyregistration.config.AppConfig
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         govukInsetText: GovukInsetText,
         appConfig: AppConfig
 )

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/OrganisationAlreadyRegisteredView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/OrganisationAlreadyRegisteredView.scala.html
@@ -15,9 +15,10 @@
  *@
 
 @import uk.gov.hmrc.economiccrimelevyregistration.config.AppConfig
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         appConfig: AppConfig
 )
 

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/OutOfSessionRegistrationSubmittedView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/OutOfSessionRegistrationSubmittedView.scala.html
@@ -16,10 +16,10 @@
 
 @import uk.gov.hmrc.economiccrimelevyregistration.config.AppConfig
 @import uk.gov.hmrc.economiccrimelevyregistration.utils.EclTaxYear
-@import uk.gov.hmrc.time.TaxYear
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         appConfig: AppConfig
 )
 

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/PartnershipNameView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/PartnershipNameView.scala.html
@@ -16,9 +16,10 @@
 
 @import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.InputWidth._
 @import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.LabelSize._
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         formHelper: FormWithCSRF,
         govukErrorSummary: GovukErrorSummary,
         govukInput: GovukInput,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/PartyTypeMismatchView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/PartyTypeMismatchView.scala.html
@@ -14,8 +14,10 @@
  * limitations under the License.
  *@
 
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
+
 @this(
-        layout: templates.Layout
+        layout: Layout
 )
 
 @()(implicit request: Request[_], messages: Messages)

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/RegisterForCurrentYearView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/RegisterForCurrentYearView.scala.html
@@ -14,21 +14,23 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.components.GovukRadios
-@import uk.gov.hmrc.govukfrontend.views.viewmodels.radios.RadioItem
-@import uk.gov.hmrc.govukfrontend.views.html.components._
-@import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.LegendSize
 @import uk.gov.hmrc.economiccrimelevyregistration.models.Mode
+@import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.LegendSize
 @import uk.gov.hmrc.economiccrimelevyregistration.views.ViewUtils
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
+@import uk.gov.hmrc.govukfrontend.views.html.components.{GovukRadios, _}
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.radios.RadioItem
+
 @import java.time.LocalDate
 
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         radios: GovukRadios,
         button: GovukButton,
         formHelper: FormWithCSRF,
         errorSummary: GovukErrorSummary
 )
+
 @(form: Form[Boolean], mode: Mode, currentYear: String, currentFinancialYearStartDate: LocalDate, currentFinancialYearEndDate: LocalDate)(implicit messages: Messages, request: Request[_])
 
 @layout(

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/RegistrationFailedView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/RegistrationFailedView.scala.html
@@ -15,9 +15,10 @@
  *@
 
 @import uk.gov.hmrc.economiccrimelevyregistration.config.AppConfig
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         appConfig: AppConfig
 )
 

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/RegistrationReceivedView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/RegistrationReceivedView.scala.html
@@ -15,10 +15,10 @@
  *@
 
 @import uk.gov.hmrc.economiccrimelevyregistration.config.AppConfig
-@import uk.gov.hmrc.economiccrimelevyregistration.utils.EclTaxYear
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         govukPanel: GovukPanel,
         appConfig: AppConfig
 )
@@ -26,8 +26,8 @@
 @(firstContactEmailAddress: String, secondContactEmailAddress: Option[String], liabilityYear: Option[LiabilityYear], registeringForCurrentYear: Boolean)(implicit request: Request[_], messages: Messages)
 
 @getPreviousYearContent() = {
-  <p class="govuk-body">@messages("registration.received.p7.previous.p1")</p>
-  <p class="govuk-body">@messages("registration.received.p7.previous.p2")</p>
+    <p class="govuk-body">@messages("registration.received.p7.previous.p1")</p>
+    <p class="govuk-body">@messages("registration.received.p7.previous.p2")</p>
 }
 @getCurrentYearContent() = {
     <p class="govuk-body">@messages("registration.received.p7.current")</p>

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/RegistrationSubmittedView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/RegistrationSubmittedView.scala.html
@@ -16,10 +16,10 @@
 
 @import uk.gov.hmrc.economiccrimelevyregistration.config.AppConfig
 @import uk.gov.hmrc.economiccrimelevyregistration.utils.EclTaxYear
-@import uk.gov.hmrc.time.TaxYear
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         govukPanel: GovukPanel,
         appConfig: AppConfig
 )

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/RelevantAp12MonthsView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/RelevantAp12MonthsView.scala.html
@@ -14,10 +14,10 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Empty
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         formHelper: FormWithCSRF,
         errorSummary: GovukErrorSummary,
         radios: GovukRadios,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/RelevantApLengthView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/RelevantApLengthView.scala.html
@@ -15,9 +15,10 @@
  *@
 
 @import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.InputWidth._
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         formHelper: FormWithCSRF,
         govukErrorSummary: GovukErrorSummary,
         govukInput: GovukInput,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/SaUtrView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/SaUtrView.scala.html
@@ -14,16 +14,14 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.govukfrontend.views.html.components.GovukButton
-@import uk.gov.hmrc.govukfrontend.views.html.components.GovukInput
-@import uk.gov.hmrc.govukfrontend.views.html.components.GovukErrorSummary
-@import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
 @import uk.gov.hmrc.economiccrimelevyregistration.models.Mode
-@import uk.gov.hmrc.economiccrimelevyregistration.views.ViewUtils.titleWithForm
 @import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.InputWidth.Fixed20
+@import uk.gov.hmrc.economiccrimelevyregistration.views.ViewUtils.titleWithForm
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
+@import uk.gov.hmrc.govukfrontend.views.html.components.{FormWithCSRF, GovukButton, GovukErrorSummary, GovukInput}
 
 @this(
-        layout: uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout,
+        layout: Layout,
         formHelper: FormWithCSRF,
         govukErrorSummary: GovukErrorSummary,
         govukInput: GovukInput,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/SavedResponsesView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/SavedResponsesView.scala.html
@@ -14,11 +14,11 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.economiccrimelevyregistration.utils.EclTaxYear
 @import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.LegendSize
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         formHelper: FormWithCSRF,
         errorSummary: GovukErrorSummary,
         radios: GovukRadios,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/SignedOutView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/SignedOutView.scala.html
@@ -14,8 +14,10 @@
  * limitations under the License.
  *@
 
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
+
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         govukButton: GovukButton
 )
 

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/StartView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/StartView.scala.html
@@ -16,10 +16,11 @@
 
 @import uk.gov.hmrc.economiccrimelevyregistration.config.AppConfig
 @import uk.gov.hmrc.economiccrimelevyregistration.utils.EclTaxYear
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
         formHelper: FormWithCSRF,
-        layout: templates.Layout,
+        layout: Layout,
         button: GovukButton,
         appConfig: AppConfig
 )
@@ -44,8 +45,8 @@
 
     <p class="govuk-body">@Html(messages("start.p2", messages("start.p2.link")))</p>
 
-    <p class="govuk-body">@messages("start.p3", EclTaxYear.yearDue)</p>
-    <p class="govuk-body">@messages("start.p4", EclTaxYear.yearDue)</p>
+    <p class="govuk-body">@messages("start.p3", EclTaxYear.yearDue.toString)</p>
+    <p class="govuk-body">@messages("start.p4", EclTaxYear.yearDue.toString)</p>
 
     <h2 class="govuk-heading-m">@messages("start.beforeYouStart")</h2>
 

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/UkRevenueView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/UkRevenueView.scala.html
@@ -14,11 +14,11 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.InputWidth._
 @import uk.gov.hmrc.hmrcfrontend.views.html.components.HmrcCurrencyInput
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         formHelper: FormWithCSRF,
         govukErrorSummary: GovukErrorSummary,
         govukInput: GovukInput,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/UserAlreadyEnrolledView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/UserAlreadyEnrolledView.scala.html
@@ -15,9 +15,10 @@
  *@
 
 @import uk.gov.hmrc.economiccrimelevyregistration.config.AppConfig
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         appConfig: AppConfig
 )
 

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/UtrTypeView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/UtrTypeView.scala.html
@@ -14,11 +14,12 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.LegendSize
 @import uk.gov.hmrc.economiccrimelevyregistration.config.AppConfig
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
+@import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.LegendSize
 
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         formHelper: FormWithCSRF,
         errorSummary: GovukErrorSummary,
         radios: GovukRadios,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/UtrView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/UtrView.scala.html
@@ -19,11 +19,12 @@
 @import uk.gov.hmrc.govukfrontend.views.html.components.GovukErrorSummary
 @import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
 @import uk.gov.hmrc.economiccrimelevyregistration.models.Mode
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 @import uk.gov.hmrc.economiccrimelevyregistration.views.ViewUtils.titleWithForm
 @import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.InputWidth.Fixed20
 
 @this(
-        layout: uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout,
+        layout: Layout,
         formHelper: FormWithCSRF,
         govukErrorSummary: GovukErrorSummary,
         govukInput: GovukInput,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/VerfificationFailedView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/VerfificationFailedView.scala.html
@@ -14,8 +14,10 @@
  * limitations under the License.
  *@
 
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
+
 @this(
-        layout: templates.Layout,
+        layout: Layout,
         insetText: GovukInsetText,
         button: GovukButton
 )

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/contacts/AddAnotherContactView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/contacts/AddAnotherContactView.scala.html
@@ -15,9 +15,10 @@
  *@
 
 @import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.LegendSize
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout,
+        layout: Layout,
         formHelper: FormWithCSRF,
         errorSummary: GovukErrorSummary,
         radios: GovukRadios,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/contacts/FirstContactEmailView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/contacts/FirstContactEmailView.scala.html
@@ -15,9 +15,10 @@
  *@
 
 @import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.InputWidth._
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout,
+        layout: Layout,
         formHelper: FormWithCSRF,
         govukErrorSummary: GovukErrorSummary,
         govukInput: GovukInput,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/contacts/FirstContactNameView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/contacts/FirstContactNameView.scala.html
@@ -15,9 +15,10 @@
  *@
 
 @import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.InputWidth._
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout,
+        layout: Layout,
         formHelper: FormWithCSRF,
         govukErrorSummary: GovukErrorSummary,
         govukInput: GovukInput,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/contacts/FirstContactNumberView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/contacts/FirstContactNumberView.scala.html
@@ -15,9 +15,10 @@
  *@
 
 @import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.InputWidth._
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout,
+        layout: Layout,
         formHelper: FormWithCSRF,
         govukErrorSummary: GovukErrorSummary,
         govukInput: GovukInput,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/contacts/FirstContactRoleView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/contacts/FirstContactRoleView.scala.html
@@ -15,9 +15,10 @@
  *@
 
 @import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.InputWidth._
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout,
+        layout: Layout,
         formHelper: FormWithCSRF,
         govukErrorSummary: GovukErrorSummary,
         govukInput: GovukInput,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/contacts/SecondContactEmailView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/contacts/SecondContactEmailView.scala.html
@@ -15,9 +15,10 @@
  *@
 
 @import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.InputWidth._
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout,
+        layout: Layout,
         formHelper: FormWithCSRF,
         govukErrorSummary: GovukErrorSummary,
         govukInput: GovukInput,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/contacts/SecondContactNameView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/contacts/SecondContactNameView.scala.html
@@ -15,9 +15,10 @@
  *@
 
 @import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.InputWidth._
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout,
+        layout: Layout,
         formHelper: FormWithCSRF,
         govukErrorSummary: GovukErrorSummary,
         govukInput: GovukInput,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/contacts/SecondContactNumberView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/contacts/SecondContactNumberView.scala.html
@@ -15,9 +15,10 @@
  *@
 
 @import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.InputWidth._
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout,
+        layout: Layout,
         formHelper: FormWithCSRF,
         govukErrorSummary: GovukErrorSummary,
         govukInput: GovukInput,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/contacts/SecondContactRoleView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/contacts/SecondContactRoleView.scala.html
@@ -15,9 +15,10 @@
  *@
 
 @import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.InputWidth._
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
-        layout: uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout,
+        layout: Layout,
         formHelper: FormWithCSRF,
         govukErrorSummary: GovukErrorSummary,
         govukInput: GovukInput,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/deregister/DeregisterCheckYourAnswersView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/deregister/DeregisterCheckYourAnswersView.scala.html
@@ -14,10 +14,9 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.checkAnswers._
 @import uk.gov.hmrc.economiccrimelevyregistration.controllers.deregister.routes._
-@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates._
 @import uk.gov.hmrc.economiccrimelevyregistration.models.RegistrationType.DeRegistration
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
         layout: Layout,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/deregister/DeregisterContactEmailView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/deregister/DeregisterContactEmailView.scala.html
@@ -14,9 +14,9 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.InputWidth._
 @import uk.gov.hmrc.economiccrimelevyregistration.controllers.deregister.routes._
-@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates._
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
+@import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.InputWidth._
 
 @this(
         layout: Layout,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/deregister/DeregisterContactNameView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/deregister/DeregisterContactNameView.scala.html
@@ -14,10 +14,10 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.InputWidth._
 @import uk.gov.hmrc.economiccrimelevyregistration.controllers.deregister.routes._
-@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates._
 @import uk.gov.hmrc.economiccrimelevyregistration.models.RegistrationType.DeRegistration
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
+@import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.InputWidth._
 
 @this(
         layout: Layout,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/deregister/DeregisterContactNumberView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/deregister/DeregisterContactNumberView.scala.html
@@ -16,7 +16,7 @@
 
 @import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.InputWidth._
 @import uk.gov.hmrc.economiccrimelevyregistration.controllers.deregister.routes._
-@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates._
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
         layout: Layout,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/deregister/DeregisterContactRoleView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/deregister/DeregisterContactRoleView.scala.html
@@ -16,7 +16,7 @@
 
 @import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.InputWidth._
 @import uk.gov.hmrc.economiccrimelevyregistration.controllers.deregister.routes._
-@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates._
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
         layout: Layout,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/deregister/DeregisterDateView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/deregister/DeregisterDateView.scala.html
@@ -17,7 +17,7 @@
 @import java.time.LocalDate
 @import uk.gov.hmrc.hmrcfrontend.views.Implicits.RichDateInput
 @import uk.gov.hmrc.economiccrimelevyregistration.controllers.deregister.routes._
-@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates._
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
         layout: Layout,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/deregister/DeregisterReasonView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/deregister/DeregisterReasonView.scala.html
@@ -18,7 +18,7 @@
 @import uk.gov.hmrc.economiccrimelevyregistration.config.AppConfig
 @import uk.gov.hmrc.economiccrimelevyregistration.models.deregister.DeregisterReason
 @import uk.gov.hmrc.economiccrimelevyregistration.controllers.deregister.routes._
-@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates._
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
         layout: Layout,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/deregister/DeregisterStartView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/deregister/DeregisterStartView.scala.html
@@ -17,7 +17,7 @@
 @import uk.gov.hmrc.economiccrimelevyregistration.config.AppConfig
 @import uk.gov.hmrc.economiccrimelevyregistration.controllers.routes
 @import uk.gov.hmrc.economiccrimelevyregistration.controllers.deregister.routes._
-@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates._
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
 
 @this(
         layout: Layout,

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/deregister/DeregistrationPdfView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/deregister/DeregistrationPdfView.scala.html
@@ -15,7 +15,6 @@
  *@
 
 @import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.PdfLayout
-@import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.checkAnswers.PdfViewModel
 
 @this(pdfLayout: PdfLayout, govukSummaryList: GovukSummaryList)
 

--- a/app/uk/gov/hmrc/economiccrimelevyregistration/views/deregister/DeregistrationRequestedView.scala.html
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/views/deregister/DeregistrationRequestedView.scala.html
@@ -15,14 +15,15 @@
  *@
 
 @import uk.gov.hmrc.economiccrimelevyregistration.config.AppConfig
-@import uk.gov.hmrc.economiccrimelevyregistration.controllers.routes
 @import uk.gov.hmrc.economiccrimelevyregistration.models.RegistrationType._
-@import uk.gov.hmrc.economiccrimelevyregistration.views.ViewUtils
 @import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.AddressViewModel
+@import uk.gov.hmrc.economiccrimelevyregistration.views.ViewUtils
+@import uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout
+
 @import java.time.LocalDate
 
 @this(
-        layout: uk.gov.hmrc.economiccrimelevyregistration.views.html.templates.Layout,
+        layout: Layout,
         govukPanel: GovukPanel,
         appConfig: AppConfig
 )

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/AmlRegulatedActivityISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/AmlRegulatedActivityISpec.scala
@@ -18,8 +18,8 @@ class AmlRegulatedActivityISpec extends ISpecBase with AuthorisedBehaviour {
     "respond with 200 status and the Aml regulated HTML view" in {
       stubAuthorisedWithNoGroupEnrolment()
 
-      val expectedTaxYearStart = EclTaxYear.currentFyStartYear
-      val expectedTaxYearEnd   = EclTaxYear.currentFyEndYear
+      val expectedTaxYearStart = EclTaxYear.currentFyStartYear.toString
+      val expectedTaxYearEnd   = EclTaxYear.currentFyFinishYear.toString
       val additionalInfo       = random[RegistrationAdditionalInfo]
 
       stubGetRegistrationAdditionalInfo(additionalInfo)

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/LiabilityBeforeCurrentYearISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/LiabilityBeforeCurrentYearISpec.scala
@@ -8,7 +8,7 @@ import uk.gov.hmrc.economiccrimelevyregistration.controllers.routes
 import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.models.RegistrationType.Initial
 import uk.gov.hmrc.economiccrimelevyregistration.models._
-import uk.gov.hmrc.time.TaxYear
+import uk.gov.hmrc.economiccrimelevyregistration.utils.EclTaxYear
 
 import java.time.LocalDate
 
@@ -148,7 +148,7 @@ class LiabilityBeforeCurrentYearISpec extends ISpecBase with AuthorisedBehaviour
           internalId = registration.internalId,
           liableForPreviousYears = Some(liableBeforeCurrentYear),
           liabilityStartDate = Some(random[LocalDate]),
-          liabilityYear = Some(LiabilityYear(TaxYear.current.previous.startYear)),
+          liabilityYear = Some(LiabilityYear(EclTaxYear.current.previous.startYear)),
           eclReference = None
         )
 

--- a/it/uk/gov/hmrc/economiccrimelevyregistration/UkRevenueISpec.scala
+++ b/it/uk/gov/hmrc/economiccrimelevyregistration/UkRevenueISpec.scala
@@ -66,7 +66,7 @@ class UkRevenueISpec extends ISpecBase with AuthorisedBehaviour {
       )
       stubUpsertRegistration(updatedRegistration)
       stubCalculateLiability(
-        CalculateLiabilityRequest(EclTaxYear.YearInDays, EclTaxYear.YearInDays, ukRevenue),
+        CalculateLiabilityRequest(EclTaxYear.yearInDays, EclTaxYear.yearInDays, ukRevenue),
         liable = true
       )
 
@@ -106,7 +106,7 @@ class UkRevenueISpec extends ISpecBase with AuthorisedBehaviour {
       stubUpsertRegistration(updatedRegistration)
 
       stubCalculateLiability(
-        CalculateLiabilityRequest(EclTaxYear.YearInDays, EclTaxYear.YearInDays, ukRevenue),
+        CalculateLiabilityRequest(EclTaxYear.yearInDays, EclTaxYear.yearInDays, ukRevenue),
         liable = false
       )
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -9,7 +9,6 @@ object AppDependencies {
     "uk.gov.hmrc"   %% s"bootstrap-frontend-play-$playVersion"            % hmrcBootstrapVersion,
     "uk.gov.hmrc"   %% s"play-frontend-hmrc-play-$playVersion"            % "8.5.0",
     "uk.gov.hmrc"   %% s"play-conditional-form-mapping-play-$playVersion" % "2.0.0",
-    "uk.gov.hmrc"   %% "tax-year"                                         % "4.0.0",
     "org.typelevel" %% "cats-core"                                        % "2.10.0"
   )
 

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/EclCalculatorConnectorSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/connectors/EclCalculatorConnectorSpec.scala
@@ -40,7 +40,7 @@ class EclCalculatorConnectorSpec extends SpecBase {
     "return the calculated liability when the http client returns the calculated liability" in forAll {
       (calculateLiabilityRequest: CalculateLiabilityRequest, calculatedLiability: CalculatedLiability) =>
         val newCalculatedLiabilityRequest =
-          calculateLiabilityRequest.copy(amlRegulatedActivityLength = EclTaxYear.YearInDays)
+          calculateLiabilityRequest.copy(amlRegulatedActivityLength = EclTaxYear.yearInDays)
         val bandRange                     = calculatedLiability.bands.small.copy(amount = BigDecimal(20000.00))
         val band                          = Bands(small = bandRange, medium = bandRange, large = bandRange, veryLarge = bandRange)
         val newCalculatedLiability        = calculatedLiability.copy(amountDue = EclAmount(BigDecimal(2000.00)), bands = band)

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/CheckYourAnswersControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/CheckYourAnswersControllerSpec.scala
@@ -33,10 +33,10 @@ import uk.gov.hmrc.economiccrimelevyregistration.models._
 import uk.gov.hmrc.economiccrimelevyregistration.models.errors._
 import uk.gov.hmrc.economiccrimelevyregistration.models.requests.RegistrationDataRequest
 import uk.gov.hmrc.economiccrimelevyregistration.services._
+import uk.gov.hmrc.economiccrimelevyregistration.utils.EclTaxYear
 import uk.gov.hmrc.economiccrimelevyregistration.viewmodels.checkAnswers._
 import uk.gov.hmrc.economiccrimelevyregistration.views.ViewUtils
 import uk.gov.hmrc.economiccrimelevyregistration.views.html._
-import uk.gov.hmrc.time.TaxYear
 
 import java.time.LocalDate
 import java.util.Base64
@@ -394,7 +394,7 @@ class CheckYourAnswersControllerSpec extends SpecBase {
   "createAndEncodeHtmlForPdf" should {
     "show liability start date" in forAll(
       Arbitrary.arbitrary[ValidRegistrationWithRegistrationType],
-      choose[Int](2022, TaxYear.current.startYear),
+      choose[Int](2022, EclTaxYear.current.startYear),
       Arbitrary.arbitrary[LocalDate],
       Arbitrary.arbitrary[EntityType].retryUntil(EntityType.isOther)
     ) {

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/EntityTypeControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/EntityTypeControllerSpec.scala
@@ -20,7 +20,6 @@ import cats.data.EitherT
 import com.danielasfregola.randomdatagenerator.RandomDataGenerator.random
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
-import org.scalacheck.Arbitrary
 import play.api.data.Form
 import play.api.http.Status.OK
 import play.api.mvc.{Call, Result}
@@ -30,7 +29,7 @@ import uk.gov.hmrc.economiccrimelevyregistration.cleanup.EntityTypeDataCleanup
 import uk.gov.hmrc.economiccrimelevyregistration.forms.EntityTypeFormProvider
 import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
 import uk.gov.hmrc.economiccrimelevyregistration.models.errors.{AuditError, DataRetrievalError}
-import uk.gov.hmrc.economiccrimelevyregistration.models.{CheckMode, EntityType, Mode, NormalMode, Registration}
+import uk.gov.hmrc.economiccrimelevyregistration.models._
 import uk.gov.hmrc.economiccrimelevyregistration.services.{AuditService, EclRegistrationService}
 import uk.gov.hmrc.economiccrimelevyregistration.views.html.EntityTypeView
 

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegisterForCurrentYearControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/RegisterForCurrentYearControllerSpec.scala
@@ -95,9 +95,9 @@ class RegisterForCurrentYearControllerSpec extends SpecBase {
           contentAsString(result) shouldBe view(
             form,
             NormalMode,
-            s"${EclTaxYear.currentFinancialYear} to ${EclTaxYear.yearDue}",
+            s"${EclTaxYear.currentStartYear()} to ${EclTaxYear.currentFinishYear()}",
             EclTaxYear.currentFinancialYearStartDate,
-            EclTaxYear.currentFinancialYearEndDate
+            EclTaxYear.currentFinancialYearFinishDate
           )(messages, fakeRequest).toString()
         }
     }
@@ -115,9 +115,9 @@ class RegisterForCurrentYearControllerSpec extends SpecBase {
           contentAsString(result) shouldBe view(
             form.fill(true),
             NormalMode,
-            s"${EclTaxYear.currentFinancialYear} to ${EclTaxYear.yearDue}",
+            s"${EclTaxYear.currentStartYear()} to ${EclTaxYear.currentFinishYear()}",
             EclTaxYear.currentFinancialYearStartDate,
-            EclTaxYear.currentFinancialYearEndDate
+            EclTaxYear.currentFinancialYearFinishDate
           )(messages, fakeRequest).toString()
         }
     }
@@ -135,9 +135,9 @@ class RegisterForCurrentYearControllerSpec extends SpecBase {
           contentAsString(result) shouldBe view(
             form.fill(false),
             NormalMode,
-            s"${EclTaxYear.currentFinancialYear} to ${EclTaxYear.yearDue}",
+            s"${EclTaxYear.currentStartYear()} to ${EclTaxYear.currentFinishYear()}",
             EclTaxYear.currentFinancialYearStartDate,
-            EclTaxYear.currentFinancialYearEndDate
+            EclTaxYear.currentFinancialYearFinishDate
           )(messages, fakeRequest).toString()
         }
     }

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/deregister/DeregistrationRequestedControllerSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/controllers/deregister/DeregistrationRequestedControllerSpec.scala
@@ -22,13 +22,12 @@ import play.api.mvc.Result
 import play.api.test.Helpers._
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
 import uk.gov.hmrc.economiccrimelevyregistration.generators.CachedArbitraries._
+import uk.gov.hmrc.economiccrimelevyregistration.models.deregister.Deregistration
 import uk.gov.hmrc.economiccrimelevyregistration.models.errors.DataRetrievalError
 import uk.gov.hmrc.economiccrimelevyregistration.models.{GetSubscriptionResponse, SessionKeys}
 import uk.gov.hmrc.economiccrimelevyregistration.services.deregister.DeregistrationService
 import uk.gov.hmrc.economiccrimelevyregistration.services.{EclRegistrationService, SessionService}
 import uk.gov.hmrc.economiccrimelevyregistration.views.html.deregister.DeregistrationRequestedView
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.actions.FakeDeregistrationRetrievalAction
-import uk.gov.hmrc.economiccrimelevyregistration.models.deregister.Deregistration
 
 import scala.concurrent.Future
 

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/models/LiabilityYearSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/models/LiabilityYearSpec.scala
@@ -18,8 +18,7 @@ package uk.gov.hmrc.economiccrimelevyregistration.models
 
 import org.scalatest.matchers.should.Matchers
 import uk.gov.hmrc.economiccrimelevyregistration.base.SpecBase
-import uk.gov.hmrc.economiccrimelevyregistration.controllers.LiabilityDateController
-import uk.gov.hmrc.time.TaxYear
+import uk.gov.hmrc.economiccrimelevyregistration.utils.EclTaxYear
 
 import java.time.LocalDate
 
@@ -27,9 +26,9 @@ class LiabilityYearSpec extends SpecBase with Matchers {
 
   class setUp(taxYear: Int) {
     def givenALiabilityStartDateOf(when: LocalDate): LiabilityYear = {
-      val year              = TaxYear.taxYearFor(when)
+      val year              = EclTaxYear.taxYearFor(when)
       val mockLiabilityYear = new LiabilityYear(year.startYear) {
-        override def currentTaxYear(): TaxYear = TaxYear(taxYear)
+        override def currentTaxYear(): EclTaxYear = EclTaxYear(taxYear)
       }
       mockLiabilityYear
     }
@@ -54,8 +53,8 @@ class LiabilityYearSpec extends SpecBase with Matchers {
       liabilityYear.asString    shouldBe "2023"
     }
 
-    "return false if liability start date is set to 5th Apr 2024 and the current tax year is 2024" in new setUp(2024) {
-      val liabilityYear: LiabilityYear = givenALiabilityStartDateOf(LocalDate.of(2024, 4, 5))
+    "return false if liability start date is set to 31st Mar 2024 and the current tax year is 2024" in new setUp(2024) {
+      val liabilityYear: LiabilityYear = givenALiabilityStartDateOf(LocalDate.of(2024, 3, 31))
       liabilityYear.isCurrentFY shouldBe false
       liabilityYear.asString    shouldBe "2023"
     }
@@ -104,8 +103,8 @@ class LiabilityYearSpec extends SpecBase with Matchers {
       liabilityYear.asString       shouldBe "2024"
     }
 
-    "return true if liability start date is set to 5th Apr 2024 and the current tax year is 2024" in new setUp(2024) {
-      val liabilityYear: LiabilityYear = givenALiabilityStartDateOf(LocalDate.of(2024, 4, 5))
+    "return true if liability start date is set to 31st Mar 2024 and the current tax year is 2024" in new setUp(2024) {
+      val liabilityYear: LiabilityYear = givenALiabilityStartDateOf(LocalDate.of(2024, 3, 31))
       liabilityYear.isNotCurrentFY shouldBe true
       liabilityYear.asString       shouldBe "2023"
     }

--- a/test/uk/gov/hmrc/economiccrimelevyregistration/services/EclCalculatorServiceSpec.scala
+++ b/test/uk/gov/hmrc/economiccrimelevyregistration/services/EclCalculatorServiceSpec.scala
@@ -43,7 +43,7 @@ class EclCalculatorServiceSpec extends SpecBase {
 
         when(
           mockEclCalculatorConnector
-            .calculateLiability(ArgumentMatchers.eq(EclTaxYear.YearInDays), ArgumentMatchers.eq(relevantApRevenue))(
+            .calculateLiability(ArgumentMatchers.eq(EclTaxYear.yearInDays), ArgumentMatchers.eq(relevantApRevenue))(
               any()
             )
         )
@@ -92,7 +92,7 @@ class EclCalculatorServiceSpec extends SpecBase {
 
         when(
           mockEclCalculatorConnector
-            .calculateLiability(ArgumentMatchers.eq(EclTaxYear.YearInDays), ArgumentMatchers.eq(relevantApRevenue))(
+            .calculateLiability(ArgumentMatchers.eq(EclTaxYear.yearInDays), ArgumentMatchers.eq(relevantApRevenue))(
               any()
             )
         )


### PR DESCRIPTION
- Removed TaxYear library

- Added functionality of the TaxYear library into EclTaxYear. Only took bits we need, and modified to use the start and end of the ECL Tax Year

- Cleaned up view imports by importing Layout instead. Views now have working syntax highlighting instead of errors.

- Needed no additional tests for **EclTaxYear** and **EclCurrentTaxYear**, as both classes already have 100% coverage through LiabilityYearSpec