### PR TITLE
ECL-905: Corrected logic on manual liability date form input

### DIFF
--- a/app/uk/gov/hmrc/economiccrimelevyregistration/forms/mappings/Constraints.scala
+++ b/app/uk/gov/hmrc/economiccrimelevyregistration/forms/mappings/Constraints.scala
@@ -105,9 +105,12 @@ trait Constraints {
     val eclTaxYear = EclTaxYear.fromDate(now)
 
     Constraint {
-      case date if eclTaxYear.isBetweenStartDateAndPreviousDateDue(date) =>
+      case date
+          if eclTaxYear
+            .isBetweenStartDateAndPreviousDateDue(date) &&
+            eclTaxYear.isBetweenStartDateAndPreviousDateDue(now) =>
         Invalid(errorKey, eclTaxYear.startYear.toString)
-      case _                                                             =>
+      case _ =>
         Valid
     }
   }


### PR DESCRIPTION
When the current date is Oct 1st 2025, you should be able to register manually for between 1st April 2024 and 30th September 2024. This fixes the logic so you can register for that scenario.